### PR TITLE
Feat/add fee markup

### DIFF
--- a/contracts/references/infinitism/IOracle.sol
+++ b/contracts/references/infinitism/IOracle.sol
@@ -1,0 +1,17 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+interface IOracle {
+    function decimals() external view returns (uint8);
+
+    function latestRoundData()
+        external
+        view
+        returns (
+            uint80 roundId,
+            int256 answer,
+            uint256 startedAt,
+            uint256 updatedAt,
+            uint80 answeredInRound
+        );
+}

--- a/contracts/references/infinitism/OracleHelper.sol
+++ b/contracts/references/infinitism/OracleHelper.sol
@@ -1,0 +1,119 @@
+// SPDX-License-Identifier: GPL-3.0
+pragma solidity ^0.8.12;
+
+/* solhint-disable not-rely-on-time */
+
+import "@uniswap/v3-periphery/contracts/interfaces/ISwapRouter.sol";
+
+import "./IOracle.sol";
+
+/// @title Helper functions for dealing with various forms of price feed oracles.
+/// @notice Maintains a price cache and updates the current price if needed.
+/// In the best case scenario we have a direct oracle from the token to the native asset.
+/// Also support tokens that have no direct price oracle to the native asset.
+/// Sometimes oracles provide the price in the opposite direction of what we need in the moment.
+abstract contract OracleHelper {
+    event TokenPriceUpdated(uint256 currentPrice, uint256 previousPrice);
+
+    uint256 private constant PRICE_DENOMINATOR = 1e6;
+
+    /// @notice Actually equals 10^(token.decimals) value used for the price calculation
+    uint256 private immutable tokenDecimalPower;
+
+    struct OracleHelperConfig {
+        /// @notice The Oracle contract used to fetch the latest token prices
+        IOracle tokenOracle;
+        /// @notice The Oracle contract used to fetch the latest ETH prices
+        IOracle nativeOracle;
+        /// @notice If 'true' we will fetch price directly from tokenOracle
+        /// @notice If 'false' we will use nativeOracle to establish a token price through a shared third currency
+        bool tokenToNativeOracle;
+        /// @notice 'true' if price is dollars-per-token, 'false' if price is tokens-per-dollar
+        bool tokenOracleReverse;
+        /// @notice 'true' if price is dollars-per-ether, 'false' if price is ether-per-dollar
+        bool nativeOracleReverse;
+        /// @notice The price update threshold percentage that triggers a price update (1e6 = 100%)
+        uint256 priceUpdateThreshold;
+        /// @notice The price cache will be returned without even fetching the oracles for this number of seconds
+        uint256 cacheTimeToLive;
+    }
+
+    /// @notice The cached token price from the Oracle, always in (ether-per-token) * PRICE_DENOMINATOR format
+    uint256 public cachedPrice;
+
+    /// @notice The timestamp of a block when the cached price was updated
+    uint256 public cachedPriceTimestamp;
+
+    OracleHelperConfig private oracleHelperConfig;
+
+    constructor(
+        OracleHelperConfig memory _oracleHelperConfig,
+        uint256 _tokenDecimalPower
+    ) {
+        cachedPrice = type(uint256).max; // initialize the storage slot to invalid value
+        tokenDecimalPower = _tokenDecimalPower;
+        _setOracleConfiguration(_oracleHelperConfig);
+    }
+
+    function _setOracleConfiguration(
+        OracleHelperConfig memory _oracleHelperConfig
+    ) internal {
+        oracleHelperConfig = _oracleHelperConfig;
+        require(
+            _oracleHelperConfig.priceUpdateThreshold <= 1e6,
+            "TPM: update threshold too high"
+        );
+    }
+
+    /// @notice Updates the token price by fetching the latest price from the Oracle.
+    function updateCachedPrice(bool force) public returns (uint256 newPrice) {
+        uint256 cacheTimeToLive = oracleHelperConfig.cacheTimeToLive;
+        uint256 priceUpdateThreshold = oracleHelperConfig.priceUpdateThreshold;
+        IOracle tokenOracle = oracleHelperConfig.tokenOracle;
+        IOracle nativeOracle = oracleHelperConfig.nativeOracle;
+
+        uint256 cacheAge = block.timestamp - cachedPriceTimestamp;
+        if (!force && cacheAge <= cacheTimeToLive) {
+            return cachedPrice;
+        }
+        uint256 _cachedPrice = cachedPrice;
+        uint256 tokenPrice = fetchPrice(tokenOracle);
+        uint256 nativeAssetPrice = fetchPrice(nativeOracle);
+        uint256 price = (nativeAssetPrice * tokenDecimalPower) / tokenPrice;
+        uint256 priceNewByOld = (price * PRICE_DENOMINATOR) / _cachedPrice;
+
+        bool updateRequired = force ||
+            priceNewByOld > PRICE_DENOMINATOR + priceUpdateThreshold ||
+            priceNewByOld < PRICE_DENOMINATOR - priceUpdateThreshold;
+        if (!updateRequired) {
+            return _cachedPrice;
+        }
+        uint256 previousPrice = _cachedPrice;
+        _cachedPrice = (nativeAssetPrice * tokenDecimalPower) / tokenPrice;
+        cachedPrice = _cachedPrice;
+        emit TokenPriceUpdated(_cachedPrice, previousPrice);
+        return _cachedPrice;
+    }
+
+    /// @notice Fetches the latest price from the given Oracle.
+    /// @dev This function is used to get the latest price from the tokenOracle or nativeOracle.
+    /// @param _oracle The Oracle contract to fetch the price from.
+    /// @return price The latest price fetched from the Oracle.
+    function fetchPrice(IOracle _oracle) internal view returns (uint256 price) {
+        (
+            uint80 roundId,
+            int256 answer,
+            ,
+            uint256 updatedAt,
+            uint80 answeredInRound
+        ) = _oracle.latestRoundData();
+        require(answer > 0, "TPM: Chainlink price <= 0");
+        // 2 days old price is considered stale since the price is updated every 24 hours
+        require(
+            updatedAt >= block.timestamp - 60 * 60 * 24 * 2,
+            "TPM: Incomplete round"
+        );
+        require(answeredInRound >= roundId, "TPM: Stale price");
+        price = uint256(answer);
+    }
+}

--- a/contracts/references/infinitism/SampleTokenPaymaster.sol
+++ b/contracts/references/infinitism/SampleTokenPaymaster.sol
@@ -1,0 +1,257 @@
+// SPDX-License-Identifier: GPL-3.0
+pragma solidity ^0.8.12;
+
+// Import the required libraries and contracts
+import "@openzeppelin/contracts/token/ERC20/extensions/IERC20Metadata.sol";
+import "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
+import "@openzeppelin/contracts/utils/cryptography/EIP712.sol";
+
+import "@account-abstraction/contracts/core/EntryPoint.sol";
+import "@account-abstraction/contracts/core/BasePaymaster.sol";
+import "./UniswapHelper.sol";
+import "./OracleHelper.sol";
+
+// TODO: note https://github.com/pimlicolabs/erc20-paymaster-contracts/issues/10
+// TODO: set a hard limit on how much gas a single user op may cost (postOp to fix the price)
+/// @title Sample ERC-20 Token Paymaster for ERC-4337
+/// @notice Based on Pimlico 'PimlicoERC20Paymaster' and OpenGSN 'PermitERC20UniswapV3Paymaster'
+/// This Paymaster covers gas fees in exchange for ERC20 tokens charged using allowance pre-issued by ERC-4337 accounts.
+/// The contract refunds excess tokens if the actual gas cost is lower than the initially provided amount.
+/// The token price cannot be queried in the validation code due to storage access restrictions of ERC-4337.
+/// The price is cached inside the contract and is updated in the 'postOp' stage if the change is >10%.
+/// It is theoretically possible the token has depreciated so much since the last 'postOp' the refund becomes negative.
+/// The contract reverts the inner user transaction in that case but keeps the charge.
+/// The contract also allows honest clients to prepay tokens at a higher price to avoid getting reverted.
+/// It also allows updating price configuration and withdrawing tokens by the contract owner.
+/// The contract uses an Oracle to fetch the latest token prices.
+/// @dev Inherits from BasePaymaster.
+contract TokenPaymaster is BasePaymaster, UniswapHelper, OracleHelper {
+    struct TokenPaymasterConfig {
+        /// @notice The price markup percentage applied to the token price (1e6 = 100%)
+        uint256 priceMarkup;
+        /// @notice Exchange tokens to native currency if the EntryPoint balance of this Paymaster falls below this value
+        uint256 minEntryPointBalance;
+    }
+
+    event ConfigUpdated(TokenPaymasterConfig tokenPaymasterConfig);
+
+    event UserOperationSponsored(
+        address indexed user,
+        uint256 actualTokenCharge,
+        uint256 actualGasCost,
+        uint256 actualTokenPrice
+    );
+
+    event PostOpReverted(address indexed user, uint256 preCharge);
+
+    event Received(address indexed sender, uint256 value);
+
+    /// @notice All 'price' variables are multiplied by this value to avoid rounding up
+    uint256 private constant PRICE_DENOMINATOR = 1e6;
+
+    /// @notice Estimated gas cost for refunding tokens after the transaction is completed
+    uint256 public constant REFUND_POSTOP_COST = 40000;
+
+    TokenPaymasterConfig private tokenPaymasterConfig;
+
+    // TODO: I don't like defaults in Solidity - accept ALL parameters of fail!!!
+    /// @notice Initializes the PimlicoERC20Paymaster contract with the given parameters.
+    /// @param _token The ERC20 token used for transaction fee payments.
+    /// @param _entryPoint The EntryPoint contract used in the Account Abstraction infrastructure.
+    /// @ param _tokenOracle The Oracle contract used to fetch the latest token prices.
+    /// @ param _nativeAssetOracle The Oracle contract used to fetch the latest native asset (ETH, Matic, Avax, etc.) prices.
+    /// @param _owner The address that will be set as the owner of the contract.
+    constructor(
+        IERC20Metadata _token,
+        IEntryPoint _entryPoint,
+        IERC20 _wrappedNative,
+        ISwapRouter _uniswap,
+        TokenPaymasterConfig memory _tokenPaymasterConfig,
+        OracleHelperConfig memory _oracleHelperConfig,
+        UniswapHelperConfig memory _uniswapHelperConfig,
+        address _owner
+    )
+        BasePaymaster(_entryPoint)
+        OracleHelper(_oracleHelperConfig, 10 ** _token.decimals())
+        UniswapHelper(_token, _wrappedNative, _uniswap, _uniswapHelperConfig)
+    {
+        setTokenPaymasterConfig(_tokenPaymasterConfig);
+        transferOwnership(_owner);
+    }
+
+    /// @notice Updates the configuration for the Token Paymaster.
+    /// @param _tokenPaymasterConfig The new price markup percentage (1e6 = 100%).
+    function setTokenPaymasterConfig(
+        TokenPaymasterConfig memory _tokenPaymasterConfig
+    ) public onlyOwner {
+        require(
+            _tokenPaymasterConfig.priceMarkup <= 1900000,
+            "TPM: price markup too high"
+        );
+        require(
+            _tokenPaymasterConfig.priceMarkup >= 1e6,
+            "TPM: price markup too low"
+        );
+        tokenPaymasterConfig = _tokenPaymasterConfig;
+        emit ConfigUpdated(_tokenPaymasterConfig);
+    }
+
+    function setOracleConfiguration(
+        OracleHelperConfig memory _oracleHelperConfig
+    ) external onlyOwner {
+        _setOracleConfiguration(_oracleHelperConfig);
+    }
+
+    function setOracleConfiguration(
+        UniswapHelperConfig memory _uniswapHelperConfig
+    ) external onlyOwner {
+        _setUniswapHelperConfiguration(_uniswapHelperConfig);
+    }
+
+    /// @notice Allows the contract owner to withdraw a specified amount of tokens from the contract.
+    /// @param to The address to transfer the tokens to.
+    /// @param amount The amount of tokens to transfer.
+    function withdrawToken(address to, uint256 amount) external onlyOwner {
+        SafeERC20.safeTransfer(token, to, amount);
+    }
+
+    /// @notice Validates a paymaster user operation and calculates the required token amount for the transaction.
+    /// @param userOp The user operation data.
+    /// @param requiredPreFund The amount of tokens required for pre-funding.
+    /// @return context The context containing the token amount and user sender address (if applicable).
+    /// @return validationResult A uint256 value indicating the result of the validation (always 0 in this implementation).
+    function _validatePaymasterUserOp(
+        UserOperation calldata userOp,
+        bytes32,
+        uint256 requiredPreFund
+    )
+        internal
+        override
+        returns (bytes memory context, uint256 validationResult)
+    {
+        unchecked {
+            uint256 priceMarkup = tokenPaymasterConfig.priceMarkup;
+            uint256 paymasterAndDataLength = userOp.paymasterAndData.length -
+                20;
+            require(
+                paymasterAndDataLength == 0 || paymasterAndDataLength == 32,
+                "TPM: invalid data length"
+            );
+            uint256 preChargeNative = requiredPreFund +
+                (REFUND_POSTOP_COST * userOp.maxFeePerGas);
+            // note: as price is in ether-per-token and we want more tokens increasing it means dividing it by markup
+            uint256 cachedPriceWithMarkup = (cachedPrice * PRICE_DENOMINATOR) /
+                priceMarkup;
+            if (paymasterAndDataLength == 32) {
+                uint256 clientSuppliedPrice = uint256(
+                    bytes32(userOp.paymasterAndData[20:52])
+                );
+                if (clientSuppliedPrice < cachedPriceWithMarkup) {
+                    // note: smaller number means 'more ether per token'
+                    cachedPriceWithMarkup = clientSuppliedPrice;
+                }
+            }
+            uint256 tokenAmount = weiToToken(
+                preChargeNative,
+                cachedPriceWithMarkup,
+                false
+            );
+            SafeERC20.safeTransferFrom(
+                token,
+                userOp.sender,
+                address(this),
+                tokenAmount
+            );
+            context = abi.encodePacked(
+                tokenAmount,
+                userOp.maxFeePerGas,
+                userOp.sender
+            );
+            validationResult = 0;
+        }
+    }
+
+    /// @notice Performs post-operation tasks, such as updating the token price and refunding excess tokens.
+    /// @dev This function is called after a user operation has been executed or reverted.
+    /// @param mode The post-operation mode (either successful or reverted).
+    /// @param context The context containing the token amount and user sender address.
+    /// @param actualGasCost The actual gas cost of the transaction.
+    function _postOp(
+        PostOpMode mode,
+        bytes calldata context,
+        uint256 actualGasCost
+    ) internal override {
+        if (mode == PostOpMode.postOpReverted) {
+            return;
+        }
+        unchecked {
+            uint256 priceMarkup = tokenPaymasterConfig.priceMarkup;
+            uint256 preCharge = uint256(bytes32(context[0:32]));
+            uint256 maxFeePerGas = uint256(bytes32(context[32:64]));
+            address userOpSender = address(bytes20(context[64:84]));
+            if (mode == PostOpMode.postOpReverted) {
+                emit PostOpReverted(userOpSender, preCharge);
+                // Do nothing here to not revert the whole bundle and harm reputation
+                return;
+            }
+            uint256 _cachedPrice = updateCachedPrice(false);
+            // note: as price is in ether-per-token and we want more tokens increasing it means dividing it by markup
+            uint256 cachedPriceWithMarkup = (_cachedPrice * PRICE_DENOMINATOR) /
+                priceMarkup;
+            // Refund tokens based on actual gas cost
+            uint256 actualChargeNative = actualGasCost +
+                REFUND_POSTOP_COST *
+                maxFeePerGas;
+            uint256 actualTokenNeeded = weiToToken(
+                actualChargeNative,
+                cachedPriceWithMarkup,
+                false
+            );
+            if (preCharge > actualTokenNeeded) {
+                // If the initially provided token amount is greater than the actual amount needed, refund the difference
+                SafeERC20.safeTransfer(
+                    token,
+                    userOpSender,
+                    preCharge - actualTokenNeeded
+                );
+            } else if (preCharge < actualTokenNeeded) {
+                // Attempt to cover Paymaster's gas expenses by withdrawing the 'overdraft' from the client
+                // If the transfer reverts also revert the 'postOp' to remove the incentive to cheat
+                SafeERC20.safeTransferFrom(
+                    token,
+                    userOpSender,
+                    address(this),
+                    actualTokenNeeded - preCharge
+                );
+            }
+
+            emit UserOperationSponsored(
+                userOpSender,
+                actualTokenNeeded,
+                actualGasCost,
+                cachedPrice
+            );
+            refillEntryPointDeposit(_cachedPrice);
+        }
+    }
+
+    /// @notice If necessary this function uses this Paymaster's token balance to refill the deposit on EntryPoint
+    function refillEntryPointDeposit(uint256 _cachedPrice) private {
+        uint256 currentEntryPointBalance = entryPoint.balanceOf(address(this));
+        if (
+            currentEntryPointBalance < tokenPaymasterConfig.minEntryPointBalance
+        ) {
+            uint256 swappedWeth = _maybeSwapTokenToWeth(
+                token,
+                _cachedPrice,
+                false
+            );
+            unwrapWeth(swappedWeth);
+            entryPoint.depositTo{value: address(this).balance}(address(this));
+        }
+    }
+
+    receive() external payable {
+        emit Received(msg.sender, msg.value);
+    }
+}

--- a/contracts/references/infinitism/UniswapHelper.sol
+++ b/contracts/references/infinitism/UniswapHelper.sol
@@ -1,0 +1,162 @@
+// SPDX-License-Identifier: GPL-3.0
+pragma solidity ^0.8.12;
+
+/* solhint-disable not-rely-on-time */
+
+import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+
+import "@uniswap/v3-periphery/contracts/interfaces/ISwapRouter.sol";
+import "@uniswap/v3-periphery/contracts/interfaces/IPeripheryPayments.sol";
+
+abstract contract UniswapHelper {
+    event UniswapReverted(
+        address tokenIn,
+        address tokenOut,
+        uint256 amountIn,
+        uint256 amountOutMin
+    );
+
+    uint256 private constant PRICE_DENOMINATOR = 1e6;
+
+    struct UniswapHelperConfig {
+        /// @notice Minimum native asset amount to receive from a single swap
+        uint256 minSwapAmount;
+        uint24 uniswapPoolFee;
+        uint8 slippage;
+    }
+
+    /// @notice The Uniswap V3 SwapRouter contract
+    ISwapRouter public immutable uniswap;
+
+    /// @notice The ERC20 token used for transaction fee payments
+    IERC20 public immutable token;
+
+    /// @notice The ERC-20 token that wraps the native asset for current chain
+    IERC20 public immutable wrappedNative;
+
+    UniswapHelperConfig private uniswapHelperConfig;
+
+    constructor(
+        IERC20 _token,
+        IERC20 _wrappedNative,
+        ISwapRouter _uniswap,
+        UniswapHelperConfig memory _uniswapHelperConfig
+    ) {
+        _token.approve(address(_uniswap), type(uint256).max);
+        token = _token;
+        wrappedNative = _wrappedNative;
+        uniswap = _uniswap;
+        _setUniswapHelperConfiguration(_uniswapHelperConfig);
+    }
+
+    function _setUniswapHelperConfiguration(
+        UniswapHelperConfig memory _uniswapHelperConfig
+    ) internal {
+        uniswapHelperConfig = _uniswapHelperConfig;
+    }
+
+    function _maybeSwapTokenToWeth(
+        IERC20 tokenIn,
+        uint256 quote,
+        bool reverseQuote
+    ) internal returns (uint256) {
+        uint256 tokenBalance = tokenIn.balanceOf(address(this));
+        uint256 amountOutMin = addSlippage(
+            tokenToWei(tokenBalance, quote, reverseQuote),
+            uniswapHelperConfig.slippage
+        );
+        if (amountOutMin < uniswapHelperConfig.minSwapAmount) {
+            return 0;
+        }
+        // note: calling 'swapToToken' but destination token is Wrapped Ether
+        return
+            swapToToken(
+                address(tokenIn),
+                address(wrappedNative),
+                tokenBalance,
+                amountOutMin,
+                uniswapHelperConfig.uniswapPoolFee
+            );
+    }
+
+    function addSlippage(
+        uint256 amount,
+        uint8 slippage
+    ) private pure returns (uint256) {
+        return (amount * (1000 - slippage)) / 1000;
+    }
+
+    function tokenToWei(
+        uint256 amount,
+        uint256 price,
+        bool reverse
+    ) internal view returns (uint256) {
+        if (reverse) {
+            return weiToToken(amount, price, false);
+        }
+        return (amount * price) / PRICE_DENOMINATOR;
+    }
+
+    function weiToToken(
+        uint256 amount,
+        uint256 price,
+        bool reverse
+    ) internal view returns (uint256) {
+        if (reverse) {
+            return tokenToWei(amount, price, false);
+        }
+        return (amount * PRICE_DENOMINATOR) / price;
+    }
+
+    // turn ERC-20 tokens into wrapped ETH at market price
+    function swapToWeth(
+        address tokenIn,
+        address wethOut,
+        uint256 amountOut,
+        uint24 fee
+    ) internal returns (uint256 amountIn) {
+        ISwapRouter.ExactOutputSingleParams memory params = ISwapRouter
+            .ExactOutputSingleParams(
+                tokenIn,
+                wethOut, //tokenOut
+                fee,
+                address(uniswap), //recipient - keep WETH at SwapRouter for withdrawal
+                block.timestamp, //deadline
+                amountOut,
+                type(uint256).max,
+                0
+            );
+        amountIn = uniswap.exactOutputSingle(params);
+    }
+
+    function unwrapWeth(uint256 amount) internal {
+        IPeripheryPayments(address(uniswap)).unwrapWETH9(amount, address(this));
+    }
+
+    // swap ERC-20 tokens at market price
+    function swapToToken(
+        address tokenIn,
+        address tokenOut,
+        uint256 amountIn,
+        uint256 amountOutMin,
+        uint24 fee
+    ) internal returns (uint256 amountOut) {
+        ISwapRouter.ExactInputSingleParams memory params = ISwapRouter
+            .ExactInputSingleParams(
+                tokenIn, //tokenIn
+                tokenOut, //tokenOut
+                fee,
+                address(uniswap),
+                block.timestamp, //deadline
+                amountIn,
+                amountOutMin,
+                0
+            );
+        try uniswap.exactInputSingle(params) returns (uint256 _amountOut) {
+            amountOut = _amountOut;
+        } catch {
+            emit UniswapReverted(tokenIn, tokenOut, amountIn, amountOutMin);
+            amountOut = 0;
+        }
+    }
+}

--- a/contracts/token/BiconomyTokenPaymaster.sol
+++ b/contracts/token/BiconomyTokenPaymaster.sol
@@ -49,6 +49,15 @@ contract BiconomyTokenPaymaster is
         ORACLE_BASED
     }
 
+    // in case flat fee needs to be enabled
+    /*enum FeePremiumMode {
+        PERCENTAGE,
+        FLAT
+    }*/
+
+    /// @notice All 'price' variables are multiplied by this value to avoid rounding up
+    uint256 private constant PRICE_DENOMINATOR = 1e6;
+
     // Gas used in EntryPoint._handlePostOp() method (including this#postOp() call)
     uint256 public UNACCOUNTED_COST = 45000; // TBD
 
@@ -579,12 +588,17 @@ contract BiconomyTokenPaymaster is
         // for below checks you would either need maxCost or some exchangeRate
 
         // review: can add some checks here on calculated value, fee cap, exchange rate
+
+        // todo: WIP x * priceMarkup / PRICE_DENOMINATOR here or later
+
         uint256 tokenRequiredPreFund = ((requiredPreFund + costOfPost) *
             exchangeRate) / 10 ** 18;
         require(
             tokenRequiredPreFund != 0,
             "BTPM: calculated token charge invalid"
         );
+
+        // check for caps after applying markup against without markup
         require(
             fee <= (tokenRequiredPreFund * 20) / 100,
             "BTPM: fee markup too high"

--- a/contracts/token/BiconomyTokenPaymaster.sol
+++ b/contracts/token/BiconomyTokenPaymaster.sol
@@ -140,6 +140,8 @@ contract BiconomyTokenPaymaster is
         uint256 gasAmountDeposited
     );
 
+    event Received(address indexed sender, uint256 value);
+
     constructor(
         address _owner,
         IEntryPoint _entryPoint,
@@ -711,5 +713,7 @@ contract BiconomyTokenPaymaster is
     }
 
     // in order to receive eth from a trade
-    receive() external payable {}
+    receive() external payable {
+        emit Received(msg.sender, msg.value);
+    }
 }

--- a/test/token-paymaster/biconomy-token-paymaster-specs.ts
+++ b/test/token-paymaster/biconomy-token-paymaster-specs.ts
@@ -35,7 +35,7 @@ const MOCK_VALID_UNTIL = "0x00000000deadbeef";
 const MOCK_VALID_AFTER = "0x0000000000001234";
 const MOCK_SIG = "0x1234";
 const MOCK_ERC20_ADDR = "0x" + "01".repeat(20);
-const MOCK_FEE = "0";
+const DEFAULT_FEE_MARKUP = 1100000;
 const WETH9 = "0x9c3C9283D3e44854697Cd22D3Faa240Cfb032889"; // not not deploying on local devnet (yet)
 // Assume TOKEN decimals is 18, then 1 ETH = 1000 TOKENS
 // const MOCK_FX = ethers.constants.WeiPerEther.mul(1000);
@@ -53,11 +53,11 @@ export const encodePaymasterData = (
   feeToken = ethers.constants.AddressZero,
   oracleAggregator = ethers.constants.AddressZero,
   exchangeRate: BigNumberish = ethers.constants.Zero,
-  fee: BigNumberish = ethers.constants.Zero
+  priceMarkup: BigNumberish = ethers.constants.Zero
 ) => {
   return ethers.utils.defaultAbiCoder.encode(
     ["uint48", "uint48", "address", "address", "uint256", "uint256"],
-    [MOCK_VALID_UNTIL, MOCK_VALID_AFTER, feeToken, oracleAggregator, exchangeRate, fee]
+    [MOCK_VALID_UNTIL, MOCK_VALID_AFTER, feeToken, oracleAggregator, exchangeRate, priceMarkup]
   );
 };
 
@@ -197,7 +197,7 @@ describe("Biconomy Token Paymaster", function () {
       const paymasterAndData = ethers.utils.hexConcat([
         paymasterAddress,
         ethers.utils.hexlify(1).slice(0, 4),
-        encodePaymasterData(token.address, oracleAggregator.address, MOCK_FX),
+        encodePaymasterData(token.address, oracleAggregator.address, MOCK_FX, DEFAULT_FEE_MARKUP),
         "0x" + "00".repeat(65),
       ]);
 
@@ -206,7 +206,7 @@ describe("Biconomy Token Paymaster", function () {
       );
 
       expect(res.priceSource).to.equal(1);
-      expect(res.fee).to.equal(ethers.constants.Zero);
+      expect(res.priceMarkup).to.equal(1100000);
       expect(res.validUntil).to.equal(ethers.BigNumber.from(MOCK_VALID_UNTIL));
       expect(res.validAfter).to.equal(ethers.BigNumber.from(MOCK_VALID_AFTER));
       expect(res.feeToken).to.equal(token.address);
@@ -281,7 +281,7 @@ describe("Biconomy Token Paymaster", function () {
         token.address,
         oracleAggregator.address,
         MOCK_FX,
-        MOCK_FEE
+        DEFAULT_FEE_MARKUP
       );
       const sig = await offchainSigner.signMessage(arrayify(hash));
       const userOp = await fillAndSign(
@@ -290,7 +290,7 @@ describe("Biconomy Token Paymaster", function () {
           paymasterAndData: ethers.utils.hexConcat([
             paymasterAddress,
             ethers.utils.hexlify(1).slice(0, 4),
-            encodePaymasterData(token.address, oracleAggregator.address, MOCK_FX),
+            encodePaymasterData(token.address, oracleAggregator.address, MOCK_FX, DEFAULT_FEE_MARKUP),
             sig,
           ]),
         },
@@ -506,7 +506,7 @@ describe("Biconomy Token Paymaster", function () {
         token.address,
         oracleAggregator.address,
         MOCK_FX,
-        MOCK_FEE
+        DEFAULT_FEE_MARKUP
       );
       const sig = await offchainSigner.signMessage(arrayify(hash));
       const userOp = await fillAndSign(
@@ -515,7 +515,7 @@ describe("Biconomy Token Paymaster", function () {
           paymasterAndData: ethers.utils.hexConcat([
             paymasterAddress,
             ethers.utils.hexlify(1).slice(0, 4),
-            encodePaymasterData(token.address, oracleAggregator.address, MOCK_FX),
+            encodePaymasterData(token.address, oracleAggregator.address, MOCK_FX, DEFAULT_FEE_MARKUP),
             sig,
           ]),
         },
@@ -542,6 +542,69 @@ describe("Biconomy Token Paymaster", function () {
       await expect(
         entryPoint.handleOps([userOp], await offchainSigner.getAddress())
       ).to.be.reverted;
+    });
+
+    it("should revert if price markup charged is too darn high", async ()  => {
+
+      const userSCW: any = BiconomyAccountImplementation__factory.connect(walletAddress, deployer)
+
+      await token
+        .connect(deployer)
+        .transfer(walletAddress, ethers.utils.parseEther("100"));
+
+      // We make transferFrom impossible by setting allowance to zero
+      const userOp1 = await fillAndSign(
+        {
+          sender: walletAddress,
+          verificationGasLimit: 200000,
+          // initCode: hexConcat([walletFactory.address, deploymentData]),
+          // nonce: 0,
+          callData: encodeERC20Approval(
+            userSCW,
+            token,
+            paymasterAddress,
+            ethers.constants.Zero 
+          ),
+        },
+        walletOwner,
+        entryPoint,
+        "nonce"
+      );
+
+      console.log("userOp");
+      console.log(userOp1);
+
+      const hash = await sampleTokenPaymaster.getHash(
+        userOp1,
+        ethers.utils.hexlify(1).slice(2, 4),
+        MOCK_VALID_UNTIL,
+        MOCK_VALID_AFTER,
+        token.address,
+        oracleAggregator.address,
+        MOCK_FX,
+        2200000 // > 2x!
+      );
+      const sig = await offchainSigner.signMessage(arrayify(hash));
+      const userOp = await fillAndSign(
+        {
+          ...userOp1,
+          paymasterAndData: ethers.utils.hexConcat([
+            paymasterAddress,
+            ethers.utils.hexlify(1).slice(0, 4),
+            encodePaymasterData(token.address, oracleAggregator.address, MOCK_FX, 2200000),
+            sig,
+          ]),
+        },
+        walletOwner,
+        entryPoint,
+        "nonce"
+      );
+
+    const initBalance = await token.balanceOf(paymasterAddress);
+
+    await expect(entryPoint.estimateGas.handleOps([userOp], await offchainSigner.getAddress()))
+    .to.to.be.revertedWithCustomError(entryPoint, "FailedOp")
+    .withArgs(0, "AA33 reverted: BTPM: price markup percentage too high");
     });
 
     

--- a/test/token-paymaster/biconomy-token-paymaster-specs.ts
+++ b/test/token-paymaster/biconomy-token-paymaster-specs.ts
@@ -206,7 +206,7 @@ describe("Biconomy Token Paymaster", function () {
       );
 
       expect(res.priceSource).to.equal(1);
-      expect(res.priceMarkup).to.equal(1100000);
+      expect(res.priceMarkup).to.equal(DEFAULT_FEE_MARKUP);
       expect(res.validUntil).to.equal(ethers.BigNumber.from(MOCK_VALID_UNTIL));
       expect(res.validAfter).to.equal(ethers.BigNumber.from(MOCK_VALID_AFTER));
       expect(res.feeToken).to.equal(token.address);
@@ -269,9 +269,6 @@ describe("Biconomy Token Paymaster", function () {
         entryPoint,
         "nonce"
       );
-
-      console.log("userOp");
-      console.log(userOp1);
 
       const hash = await sampleTokenPaymaster.getHash(
         userOp1,
@@ -495,9 +492,6 @@ describe("Biconomy Token Paymaster", function () {
         "nonce"
       );
 
-      console.log("userOp");
-      console.log(userOp1);
-
       const hash = await sampleTokenPaymaster.getHash(
         userOp1,
         ethers.utils.hexlify(1).slice(2, 4),
@@ -570,9 +564,6 @@ describe("Biconomy Token Paymaster", function () {
         entryPoint,
         "nonce"
       );
-
-      console.log("userOp");
-      console.log(userOp1);
 
       const hash = await sampleTokenPaymaster.getHash(
         userOp1,

--- a/test/token-paymaster/btpm-coverage-specs.ts
+++ b/test/token-paymaster/btpm-coverage-specs.ts
@@ -33,7 +33,7 @@ const MOCK_VALID_UNTIL = "0x00000000deadbeef";
 const MOCK_VALID_AFTER = "0x0000000000001234";
 const MOCK_SIG = "0x1234";
 const MOCK_ERC20_ADDR = "0x" + "01".repeat(20);
-const MOCK_FEE = "0";
+const DEFAULT_FEE_MARKUP = 1100000;
 const WETH9 = "0x9c3C9283D3e44854697Cd22D3Faa240Cfb032889"; // not not deploying on local devnet (yet)
 // Assume TOKEN decimals is 18, then 1 ETH = 1000 TOKENS
 // const MOCK_FX = ethers.constants.WeiPerEther.mul(1000);
@@ -49,12 +49,13 @@ export async function deployEntryPoint(
 
 export const encodePaymasterData = (
   feeToken = ethers.constants.AddressZero,
+  oracleAggregator = ethers.constants.AddressZero,
   exchangeRate: BigNumberish = ethers.constants.Zero,
-  fee: BigNumberish = ethers.constants.Zero
+  priceMarkup: BigNumberish = ethers.constants.Zero
 ) => {
   return ethers.utils.defaultAbiCoder.encode(
-    ["uint48", "uint48", "address", "uint256", "uint256"],
-    [MOCK_VALID_UNTIL, MOCK_VALID_AFTER, feeToken, exchangeRate, fee]
+    ["uint48", "uint48", "address", "address", "uint256", "uint256"],
+    [MOCK_VALID_UNTIL, MOCK_VALID_AFTER, feeToken, oracleAggregator, exchangeRate, priceMarkup]
   );
 };
 

--- a/test/token-paymaster/btpm-coverage-specs.ts
+++ b/test/token-paymaster/btpm-coverage-specs.ts
@@ -31,9 +31,6 @@ import { BigNumber, BigNumberish, Contract, Signer } from "ethers";
 
 const MOCK_VALID_UNTIL = "0x00000000deadbeef";
 const MOCK_VALID_AFTER = "0x0000000000001234";
-const MOCK_SIG = "0x1234";
-const MOCK_ERC20_ADDR = "0x" + "01".repeat(20);
-const DEFAULT_FEE_MARKUP = 1100000;
 const WETH9 = "0x9c3C9283D3e44854697Cd22D3Faa240Cfb032889"; // not not deploying on local devnet (yet)
 // Assume TOKEN decimals is 18, then 1 ETH = 1000 TOKENS
 // const MOCK_FX = ethers.constants.WeiPerEther.mul(1000);

--- a/test/token-paymaster/btpm-undeployed-wallet.ts
+++ b/test/token-paymaster/btpm-undeployed-wallet.ts
@@ -270,9 +270,6 @@ describe("Biconomy Token Paymaster", function () {
         "nonce"
       );
 
-      console.log("userOp");
-      console.log(userOp1);
-
       const hash = await sampleTokenPaymaster.getHash(
         userOp1,
         ethers.utils.hexlify(1).slice(2, 4),

--- a/test/token-paymaster/btpm-undeployed-wallet.ts
+++ b/test/token-paymaster/btpm-undeployed-wallet.ts
@@ -34,7 +34,7 @@ const MOCK_VALID_UNTIL = "0x00000000deadbeef";
 const MOCK_VALID_AFTER = "0x0000000000001234";
 const MOCK_SIG = "0x1234";
 const MOCK_ERC20_ADDR = "0x" + "01".repeat(20);
-const MOCK_FEE = "0";
+const DEFAULT_FEE_MARKUP = 1100000;
 const WETH9 = "0x9c3C9283D3e44854697Cd22D3Faa240Cfb032889"; // not not deploying on local devnet (yet)
 // Assume TOKEN decimals is 18, then 1 ETH = 1000 TOKENS
 // const MOCK_FX = ethers.constants.WeiPerEther.mul(1000);
@@ -52,11 +52,11 @@ export const encodePaymasterData = (
   feeToken = ethers.constants.AddressZero,
   oracleAggregator = ethers.constants.AddressZero,
   exchangeRate: BigNumberish = ethers.constants.Zero,
-  fee: BigNumberish = ethers.constants.Zero
+  priceMarkup: BigNumberish = ethers.constants.Zero
 ) => {
   return ethers.utils.defaultAbiCoder.encode(
     ["uint48", "uint48", "address", "address", "uint256", "uint256"],
-    [MOCK_VALID_UNTIL, MOCK_VALID_AFTER, feeToken, oracleAggregator, exchangeRate, fee]
+    [MOCK_VALID_UNTIL, MOCK_VALID_AFTER, feeToken, oracleAggregator, exchangeRate, priceMarkup]
   );
 };
 
@@ -196,7 +196,7 @@ describe("Biconomy Token Paymaster", function () {
       const paymasterAndData = ethers.utils.hexConcat([
         paymasterAddress,
         ethers.utils.hexlify(1).slice(0, 4),
-        encodePaymasterData(token.address, oracleAggregator.address, MOCK_FX),
+        encodePaymasterData(token.address, oracleAggregator.address, MOCK_FX, DEFAULT_FEE_MARKUP),
         "0x" + "00".repeat(65),
       ]);
 
@@ -205,7 +205,7 @@ describe("Biconomy Token Paymaster", function () {
       );
 
       expect(res.priceSource).to.equal(1);
-      expect(res.fee).to.equal(ethers.constants.Zero);
+      expect(res.priceMarkup).to.equal(DEFAULT_FEE_MARKUP);
       expect(res.validUntil).to.equal(ethers.BigNumber.from(MOCK_VALID_UNTIL));
       expect(res.validAfter).to.equal(ethers.BigNumber.from(MOCK_VALID_AFTER));
       expect(res.feeToken).to.equal(token.address);
@@ -281,7 +281,7 @@ describe("Biconomy Token Paymaster", function () {
         token.address,
         oracleAggregator.address,
         MOCK_FX,
-        MOCK_FEE
+        DEFAULT_FEE_MARKUP
       );
       const sig = await offchainSigner.signMessage(arrayify(hash));
       const userOp = await fillAndSign(
@@ -290,7 +290,7 @@ describe("Biconomy Token Paymaster", function () {
           paymasterAndData: ethers.utils.hexConcat([
             paymasterAddress,
             ethers.utils.hexlify(1).slice(0, 4),
-            encodePaymasterData(token.address, oracleAggregator.address, MOCK_FX),
+            encodePaymasterData(token.address, oracleAggregator.address, MOCK_FX, DEFAULT_FEE_MARKUP),
             sig,
           ]),
         },


### PR DESCRIPTION
Added another sample paymaster in references.

Notion of flat fee now changes to price markup.

price markup = % unit = 1e6 = 100% = 1x
so to charge 20% extra you would send 1200000.
this gets capped at 2e6 = 2x calculatedTokenCost