### PR TITLE
feat: attempt to charge tokens in second handlepostop call

### DIFF
--- a/test/token-paymaster/biconomy-token-paymaster-specs.ts
+++ b/test/token-paymaster/biconomy-token-paymaster-specs.ts
@@ -574,20 +574,15 @@ describe("Biconomy Token Paymaster", function () {
         "nonce"
       );
 
-    const initBalance = await token.balanceOf(paymasterAddress);
-
-      await expect(entryPoint.handleOps(
+    await entryPoint.handleOps(
         [userOp],
-        await offchainSigner.getAddress()
-      )).to.emit(sampleTokenPaymaster, "TokenPaymentDue")
-
+        await offchainSigner.getAddress())
 
     const postBalance = await token.balanceOf(paymasterAddress);
 
     const ev = await getUserOpEvent(entryPoint);
     // Review this because despite explicit revert bundler still pays gas
     expect(ev.args.success).to.be.false;
-    expect(postBalance.sub(initBalance)).to.equal(ethers.constants.Zero);
 
       await expect(
         entryPoint.handleOps([userOp], await offchainSigner.getAddress())


### PR DESCRIPTION
If the first postOp call reverts it makes executeUserOp revert as well
In this case - (unless the user transferred tokens outside of this operation or allowance did not meet) transferred tokens or set allowance to zero as part of userop.calldata then tokens would still reside in sender account. and can be charged again!

if this attempt fails too then emit the TokenPaymentDue event as usual 