### PR TITLE
Features/sma 233 gas opt 2

### DIFF
--- a/contracts/test/helpers/MockChainlinkAggregator.sol
+++ b/contracts/test/helpers/MockChainlinkAggregator.sol
@@ -83,14 +83,14 @@ contract MockChainlinkOracleAggregator is Ownable, IOracleAggregator {
      */
     function getTokenValueOfOneNativeToken(
         address token
-    ) external view virtual returns (uint256 exchangeRate) {
+    ) external view virtual returns (uint128 exchangeRate) {
         // we'd actually want eth / token
         uint256 tokenPriceUnadjusted = _getTokenPrice(token);
         uint8 _tokenOracleDecimals = tokensInfo[token].decimals;
         exchangeRate =
-            ((10 ** _tokenOracleDecimals) *
+            uint128(((10 ** _tokenOracleDecimals) *
                 (10 ** IERC20Metadata(token).decimals())) /
-            tokenPriceUnadjusted;
+            tokenPriceUnadjusted);
     }
 
     // Making explicit revert or make use of stale price feed which reverts

--- a/contracts/test/helpers/MockOracle.sol
+++ b/contracts/test/helpers/MockOracle.sol
@@ -1,0 +1,65 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+import "@chainlink/contracts/src/v0.8/interfaces/AggregatorV3Interface.sol";
+
+contract MockOracle is AggregatorV3Interface {
+
+    uint256 internal priceToReturn;
+    string internal desc;
+
+    constructor(uint256 _fixedPrice, string memory _description) {
+        priceToReturn = _fixedPrice;
+        desc = _description;
+    }
+
+    function decimals() public view returns (uint8) {
+        return 8;
+    }
+
+    function description() public view returns (string memory) {
+        return desc;
+    }
+
+    function version() public view returns (uint256) {
+        return 1;
+    }
+
+    function getRoundData(uint80 _roundId)
+        public
+        view
+        override
+        returns (
+            uint80 roundId,
+            int256 answer,
+            uint256 startedAt,
+            uint256 updatedAt,
+            uint80 answeredInRound
+        )
+    {
+        roundId = _roundId;
+        answer = int256(priceToReturn);
+        startedAt = 0;
+        updatedAt = 0;
+        answeredInRound = 0;
+    }
+
+    function latestRoundData()
+        public
+        view
+        virtual
+        returns (
+            uint80 roundId,
+            int256 answer,
+            uint256 startedAt,
+            uint256 updatedAt,
+            uint80 answeredInRound
+        )
+    {
+        roundId = 36893488147419318063;
+        answer = int256(priceToReturn);
+        startedAt = 1780336251;
+        updatedAt = 1780509051;
+        answeredInRound = 36893488147419318063;
+    }
+}

--- a/contracts/token/BiconomyTokenPaymaster.sol
+++ b/contracts/token/BiconomyTokenPaymaster.sol
@@ -110,7 +110,7 @@ contract BiconomyTokenPaymaster is
      * Designed to enable tracking how much fees were charged from the sender and in which ERC20 token
      * More information can be emitted like exchangeRate used, what was the source of exchangeRate etc*/
     // priceMarkup = Multiplier value to calculate markup, 1e6 means 1x multiplier = No markup
-    event TokenPaymasterOperation(
+    /*event TokenPaymasterOperation(
         address indexed sender,
         address indexed token,
         uint256 indexed totalCharge,
@@ -118,6 +118,14 @@ contract BiconomyTokenPaymaster is
         bytes32 userOpHash,
         uint256 exchangeRate,
         ExchangeRateSource priceSource
+    );*/
+
+    // Review can add exchangeRate
+    event UserOperationSponsored(
+        address indexed sender,
+        address indexed token,
+        uint256 indexed totalCharge,
+        uint256 actualGasCost
     );
 
     /**
@@ -487,17 +495,9 @@ contract BiconomyTokenPaymaster is
             feeToken,
             priceSource,
             exchangeRate,
-            priceMarkup,
-            userOpHash
+            priceMarkup //,
+            // userOpHash
         );
-        // console.log("gas used for context encode: %s", gas - gasleft());
-
-        // console.log("account: %s", account);
-        // console.log("feeToken: %s", address(feeToken));
-        // console.log("priceSource: %s", uint8(priceSource));
-        // console.log("exchangeRate: %s", exchangeRate);
-        // console.log("priceMarkup: %s", priceMarkup);
-        // console.log("userOpHash: %s", uint256(userOpHash));
 
         return (
             context,
@@ -516,32 +516,12 @@ contract BiconomyTokenPaymaster is
         bytes calldata context,
         uint256 actualGasCost
     ) internal virtual override {
-        // uint256 gas = gasleft();
-        // (
-        //     address account,
-        //     IERC20 feeToken,
-        //     ExchangeRateSource priceSource,
-        //     uint256 exchangeRate,
-        //     uint32 priceMarkup,
-        //     bytes32 userOpHash
-        // ) = abi.decode(
-        //         context,
-        //         (
-        //             address,
-        //             IERC20,
-        //             address,
-        //             ExchangeRateSource,
-        //             uint256,
-        //             uint32,
-        //             bytes32
-        //         )
-        //     );
         address account;
         IERC20 feeToken;
         ExchangeRateSource priceSource;
         uint256 exchangeRate;
         uint32 priceMarkup;
-        bytes32 userOpHash;
+       // bytes32 userOpHash;
         assembly ("memory-safe") {
             let offset := context.offset
 
@@ -558,9 +538,9 @@ contract BiconomyTokenPaymaster is
             offset := add(offset, 0x20)
 
             priceMarkup := calldataload(offset)
-            offset := add(offset, 0x20)
+            // offset := add(offset, 0x20)
 
-            userOpHash := calldataload(offset)
+            // userOpHash := calldataload(offset)
         }
 
         uint256 effectiveExchangeRate = exchangeRate;
@@ -590,7 +570,7 @@ contract BiconomyTokenPaymaster is
                 feeReceiver,
                 charge
             );
-            emit TokenPaymasterOperation(
+            /*emit TokenPaymasterOperation(
                 account,
                 address(feeToken),
                 charge,
@@ -598,7 +578,8 @@ contract BiconomyTokenPaymaster is
                 userOpHash,
                 effectiveExchangeRate,
                 priceSource
-            );
+            );*/
+            emit UserOperationSponsored(account, address(feeToken), charge, actualGasCost);
         } else {
             // In case transferFrom failed in first handlePostOp call, attempt to charge the tokens again
             bytes memory _data = abi.encodeWithSelector(

--- a/contracts/token/BiconomyTokenPaymaster.sol
+++ b/contracts/token/BiconomyTokenPaymaster.sol
@@ -110,7 +110,7 @@ contract BiconomyTokenPaymaster is
      * Designed to enable tracking how much fees were charged from the sender and in which ERC20 token
      * More information can be emitted like exchangeRate used, what was the source of exchangeRate etc*/
     // priceMarkup = Multiplier value to calculate markup, 1e6 means 1x multiplier = No markup
-    /*event TokenPaymasterOperation(
+    event TokenPaymasterOperation(
         address indexed sender,
         address indexed token,
         uint256 indexed totalCharge,
@@ -118,15 +118,16 @@ contract BiconomyTokenPaymaster is
         bytes32 userOpHash,
         uint256 exchangeRate,
         ExchangeRateSource priceSource
-    );*/
+    );
 
-    // Review can add exchangeRate
-    event UserOperationSponsored(
+    // Review can replace with this event // can add exchangeRate
+    // saves 1000 gas
+    /*event UserOperationSponsored(
         address indexed sender,
         address indexed token,
         uint256 indexed totalCharge,
         uint256 actualGasCost
-    );
+    );*/
 
     /**
      * Notify in case paymaster failed to withdraw tokens from sender
@@ -495,8 +496,8 @@ contract BiconomyTokenPaymaster is
             feeToken,
             priceSource,
             exchangeRate,
-            priceMarkup //,
-            // userOpHash
+            priceMarkup,
+            userOpHash
         );
 
         return (
@@ -521,7 +522,7 @@ contract BiconomyTokenPaymaster is
         ExchangeRateSource priceSource;
         uint256 exchangeRate;
         uint32 priceMarkup;
-       // bytes32 userOpHash;
+        bytes32 userOpHash;
         assembly ("memory-safe") {
             let offset := context.offset
 
@@ -538,9 +539,9 @@ contract BiconomyTokenPaymaster is
             offset := add(offset, 0x20)
 
             priceMarkup := calldataload(offset)
-            // offset := add(offset, 0x20)
+            offset := add(offset, 0x20)
 
-            // userOpHash := calldataload(offset)
+            userOpHash := calldataload(offset)
         }
 
         uint256 effectiveExchangeRate = exchangeRate;
@@ -570,7 +571,7 @@ contract BiconomyTokenPaymaster is
                 feeReceiver,
                 charge
             );
-            /*emit TokenPaymasterOperation(
+            emit TokenPaymasterOperation(
                 account,
                 address(feeToken),
                 charge,
@@ -578,8 +579,8 @@ contract BiconomyTokenPaymaster is
                 userOpHash,
                 effectiveExchangeRate,
                 priceSource
-            );*/
-            emit UserOperationSponsored(account, address(feeToken), charge, actualGasCost);
+            );
+            // emit UserOperationSponsored(account, address(feeToken), charge, actualGasCost);
         } else {
             // In case transferFrom failed in first handlePostOp call, attempt to charge the tokens again
             bytes memory _data = abi.encodeWithSelector(

--- a/contracts/token/BiconomyTokenPaymaster.sol
+++ b/contracts/token/BiconomyTokenPaymaster.sol
@@ -73,11 +73,11 @@ contract BiconomyTokenPaymaster is
     // receiver of withdrawn fee tokens
     address public feeReceiver;
 
-    // paymasterAndData: concat of [paymasterAddress(address), priceSource(enum 1 byte), abi.encode(validUntil, validAfter, feeToken, exchangeRate, priceMarkup): makes up 32*5 bytes, signature]
+    // paymasterAndData: concat of [paymasterAddress(address), priceSource(enum 1 byte), validUntil(6 byte), validAfter(6 byte), feeToken(20 bytes), exchangeRate(16 bytes), priceMarkup(4 bytes), signature]
     // PND offset is used to indicate offsets to decode, used along with Signature offset
     uint256 private constant VALID_PND_OFFSET = 21;
 
-    uint256 private constant SIGNATURE_OFFSET = 181;
+    uint256 private constant SIGNATURE_OFFSET = 73;
 
     /**
      * Designed to enable the community to track change in storage variable UNACCOUNTED_COST which is used
@@ -116,7 +116,7 @@ contract BiconomyTokenPaymaster is
         uint256 indexed totalCharge,
         uint32 priceMarkup,
         bytes32 userOpHash,
-        uint256 exchangeRate,
+        uint128 exchangeRate,
         ExchangeRateSource priceSource
     );
 
@@ -340,7 +340,7 @@ contract BiconomyTokenPaymaster is
         uint48 validUntil,
         uint48 validAfter,
         address feeToken,
-        uint256 exchangeRate,
+        uint128 exchangeRate,
         uint32 priceMarkup
     ) public view returns (bytes32) {
         //can't use userOp.hash(), since it contains also the paymasterAndData itself.
@@ -378,7 +378,7 @@ contract BiconomyTokenPaymaster is
             uint48 validUntil,
             uint48 validAfter,
             address feeToken,
-            uint256 exchangeRate,
+            uint128 exchangeRate,
             uint32 priceMarkup,
             bytes calldata signature
         )
@@ -393,16 +393,11 @@ contract BiconomyTokenPaymaster is
                 bytes1(paymasterAndData[VALID_PND_OFFSET - 1:VALID_PND_OFFSET])
             )
         );
-        (
-            validUntil,
-            validAfter,
-            feeToken,
-            exchangeRate,
-            priceMarkup
-        ) = abi.decode(
-            paymasterAndData[VALID_PND_OFFSET:SIGNATURE_OFFSET],
-            (uint48, uint48, address, uint256, uint32)
-        );
+        validUntil = uint48(bytes6(paymasterAndData[21:27]));
+        validAfter = uint48(bytes6(paymasterAndData[27:33]));
+        feeToken = address(bytes20(paymasterAndData[33:53]));
+        exchangeRate = uint128(bytes16(paymasterAndData[53:69]));
+        priceMarkup = uint32(bytes4(paymasterAndData[69:73]));
         signature = paymasterAndData[SIGNATURE_OFFSET:];
     }
 
@@ -447,7 +442,7 @@ contract BiconomyTokenPaymaster is
             uint48 validUntil,
             uint48 validAfter,
             address feeToken,
-            uint256 exchangeRate,
+            uint128 exchangeRate,
             uint32 priceMarkup,
             bytes calldata signature
         ) = parsePaymasterAndData(userOp.paymasterAndData);
@@ -520,7 +515,7 @@ contract BiconomyTokenPaymaster is
         address account;
         IERC20 feeToken;
         ExchangeRateSource priceSource;
-        uint256 exchangeRate;
+        uint128 exchangeRate;
         uint32 priceMarkup;
         bytes32 userOpHash;
         assembly ("memory-safe") {
@@ -544,7 +539,7 @@ contract BiconomyTokenPaymaster is
             userOpHash := calldataload(offset)
         }
 
-        uint256 effectiveExchangeRate = exchangeRate;
+        uint128 effectiveExchangeRate = exchangeRate;
 
         if (
             priceSource == ExchangeRateSource.ORACLE_BASED 

--- a/contracts/token/oracles/ChainlinkOracleAggregator.sol
+++ b/contracts/token/oracles/ChainlinkOracleAggregator.sol
@@ -80,15 +80,15 @@ contract ChainlinkOracleAggregator is Ownable, IOracleAggregator {
      */
     function getTokenValueOfOneNativeToken(
         address token
-    ) external view virtual returns (uint256 exchangeRate) {
+    ) external view virtual returns (uint128 exchangeRate) {
         // we'd actually want eth / token
         (
             uint256 tokenPrice,
             uint8 tokenOracleDecimals
         ) = _getTokenPriceAndDecimals(token);
         exchangeRate =
-            10 ** (tokenOracleDecimals + IERC20Metadata(token).decimals()) /
-            tokenPrice;
+            uint128(10 ** (tokenOracleDecimals + IERC20Metadata(token).decimals()) /
+            tokenPrice);
     }
 
     function _getTokenPriceAndDecimals(

--- a/contracts/token/oracles/FeedInterface.sol
+++ b/contracts/token/oracles/FeedInterface.sol
@@ -15,6 +15,8 @@ interface FeedInterface {
         uint256 startedAt
     );
 
+    function decimals() external view returns (uint8);
+
     function latestAnswer() external view returns (int256);
 
     function latestTimestamp() external view returns (uint256);

--- a/contracts/token/oracles/IOracleAggregator.sol
+++ b/contracts/token/oracles/IOracleAggregator.sol
@@ -4,5 +4,5 @@ pragma solidity ^0.8.20;
 interface IOracleAggregator {
     function getTokenValueOfOneNativeToken(
         address _token
-    ) external view returns (uint256 exchangeRate);
+    ) external view returns (uint128 exchangeRate);
 }

--- a/contracts/token/oracles/OracleAggregator.sol
+++ b/contracts/token/oracles/OracleAggregator.sol
@@ -3,12 +3,15 @@ pragma solidity ^0.8.20;
 
 import "@openzeppelin/contracts/access/Ownable.sol";
 import "./IOracleAggregator.sol";
-import "./IPriceOracle.sol";
 import "./FeedInterface.sol";
 
 abstract contract OracleAggregator is Ownable, IOracleAggregator {
 
     error MismatchInBaseAndQuoteDecimals();
+    error InvalidPriceFromRound();
+    error LatestRoundIncomplete();
+    error PriceFeedStale();
+    error OracleAddressCannotBeZero();
 
      struct TokenInfo {
         uint8 tokenDecimals;
@@ -30,18 +33,15 @@ abstract contract OracleAggregator is Ownable, IOracleAggregator {
         address nativeOracle,
         bool isDerivedFeed
     ) external onlyOwner {
-        require(
-            tokenOracle != address(0),
-            "feed address can not be zero"
-        );
-        require(
-            nativeOracle != address(0),
-            "feed address can not be zero"
-        );
+        if(tokenOracle == address(0)) revert OracleAddressCannotBeZero();
+        if(nativeOracle == address(0)) revert OracleAddressCannotBeZero();
         require(
             token != address(0),
             "token address can not be zero"
         );
+        uint8 decimals1 = FeedInterface(nativeOracle).decimals();
+        uint8 decimals2 = FeedInterface(tokenOracle).decimals();
+        if (decimals1 != decimals2) revert MismatchInBaseAndQuoteDecimals();
         tokensInfo[token].tokenOracle = tokenOracle;
         tokensInfo[token].nativeOracle = nativeOracle;
         tokensInfo[token].tokenDecimals = tokenDecimals;
@@ -78,19 +78,13 @@ abstract contract OracleAggregator is Ownable, IOracleAggregator {
         tokenDecimals = tokenInfo.tokenDecimals;
 
         if (tokenInfo.isDerivedFeed) {
-            //uint8 decimals1 = FeedInterface(tokenInfo.nativeOracle).decimals();
-            //uint8 decimals2 = FeedInterface(tokenInfo.tokenOracle).decimals();
-            //if (decimals1 != decimals2) revert MismatchInBaseAndQuoteDecimals();
-
-            uint256 price1 = fetchPrice(IPriceOracle(tokenInfo.nativeOracle));
-
-            uint256 price2 = fetchPrice(IPriceOracle(tokenInfo.tokenOracle));
-
+            uint256 price1 = fetchPrice(FeedInterface(tokenInfo.nativeOracle));
+            uint256 price2 = fetchPrice(FeedInterface(tokenInfo.tokenOracle));
             tokenPrice = (price2 * (10 ** 18)) / price1;
             tokenOracleDecimals = 18;
         } else {
              tokenPrice = 
-                fetchPrice(IPriceOracle(tokenInfo.tokenOracle));
+                fetchPrice(FeedInterface(tokenInfo.tokenOracle));
              tokenOracleDecimals = FeedInterface(tokenInfo.tokenOracle).decimals();
         }
     }
@@ -99,7 +93,7 @@ abstract contract OracleAggregator is Ownable, IOracleAggregator {
     /// @dev This function is used to get the latest price from the tokenOracle or nativeOracle.
     /// @param _oracle The Oracle contract to fetch the price from.
     /// @return price The latest price fetched from the Oracle.
-    function fetchPrice(IPriceOracle _oracle) internal view returns (uint256 price) {
+    function fetchPrice(FeedInterface _oracle) internal view returns (uint256 price) {
         (
             uint80 roundId,
             int256 answer,
@@ -107,13 +101,14 @@ abstract contract OracleAggregator is Ownable, IOracleAggregator {
             uint256 updatedAt,
             uint80 answeredInRound
         ) = _oracle.latestRoundData();
-        require(answer > 0, "BTPM: Chainlink price <= 0");
+
+        // validateRound
+        if (answer <= 0) revert InvalidPriceFromRound();
         // 2 days old price is considered stale since the price is updated every 24 hours
-        require(
-            updatedAt >= block.timestamp - 60 * 60 * 24 * 2,
-            "BTPM: Incomplete round"
-        );
-        require(answeredInRound >= roundId, "BTPM: Stale price");
+        if (updatedAt < block.timestamp - 60 * 60 * 24 * 2)
+            revert PriceFeedStale();
+        if (answeredInRound < roundId) revert PriceFeedStale();
+
         price = uint256(answer);
     }    
 }

--- a/contracts/token/oracles/OracleAggregator.sol
+++ b/contracts/token/oracles/OracleAggregator.sol
@@ -55,7 +55,7 @@ abstract contract OracleAggregator is Ownable, IOracleAggregator {
      */
     function getTokenValueOfOneNativeToken(
         address token
-    ) public view returns (uint256 exchangeRate) {
+    ) public view returns (uint128 exchangeRate) {
         // we'd actually want eth / token
         (
             uint256 tokenPrice,
@@ -63,8 +63,8 @@ abstract contract OracleAggregator is Ownable, IOracleAggregator {
             uint8 tokenDecimals
         ) = _getTokenPriceAndDecimals(token);
         exchangeRate =
-            10 ** (tokenOracleDecimals + tokenDecimals) /
-            tokenPrice;
+            uint128(10 ** (tokenOracleDecimals + tokenDecimals) /
+            tokenPrice);
     }
 
     function _getTokenPriceAndDecimals(

--- a/test/bundler-integration/token-paymaster/biconomy-token-paymaster-specs.ts
+++ b/test/bundler-integration/token-paymaster/biconomy-token-paymaster-specs.ts
@@ -14,6 +14,7 @@ import {
   BiconomyTokenPaymaster__factory,
   MockPriceFeed__factory,
   MockToken,
+  MockOracle__factory,
 } from "../../../typechain-types";
 
 // Review: Could import from scw-contracts submodules to be consistent
@@ -132,6 +133,15 @@ describe("Biconomy Token Paymaster (with Bundler)", function () {
       usdcMaticPriceFeedMock.address
     );
 
+    const nativeOracle = await new MockOracle__factory(deployer).deploy(
+      82843594,
+      "MATIC/USD"
+    );
+    const tokenOracle = await new MockOracle__factory(deployer).deploy(
+      100000000,
+      "USDC/USD"
+    );
+
     sampleTokenPaymaster = await new BiconomyTokenPaymaster__factory(
       deployer
     ).deploy(
@@ -142,9 +152,9 @@ describe("Biconomy Token Paymaster (with Bundler)", function () {
 
     await sampleTokenPaymaster.setTokenOracle(
       token.address,
-      18,
       await token.decimals(),
-      usdcMaticPriceFeedMock.address,
+      tokenOracle.address,
+      nativeOracle.address,
       true
     );
 

--- a/test/bundler-integration/token-paymaster/biconomy-token-paymaster-specs.ts
+++ b/test/bundler-integration/token-paymaster/biconomy-token-paymaster-specs.ts
@@ -48,16 +48,16 @@ export async function deployEntryPoint(
   return new EntryPoint__factory(provider.getSigner()).deploy();
 }
 
-export const encodePaymasterData = (
-  feeToken = ethers.constants.AddressZero,
-  exchangeRate: BigNumberish = ethers.constants.Zero,
-  priceMarkup: BigNumberish = ethers.constants.Zero
-) => {
-  return ethers.utils.defaultAbiCoder.encode(
-    ["uint48", "uint48", "address", "uint256", "uint32"],
-    [MOCK_VALID_UNTIL, MOCK_VALID_AFTER, feeToken, exchangeRate, priceMarkup]
-  );
-};
+// export const encodePaymasterData = (
+//   feeToken = ethers.constants.AddressZero,
+//   exchangeRate: BigNumberish = ethers.constants.Zero,
+//   priceMarkup: BigNumberish = ethers.constants.Zero
+// ) => {
+//   return ethers.utils.defaultAbiCoder.encode(
+//     ["uint48", "uint48", "address", "uint256", "uint32"],
+//     [MOCK_VALID_UNTIL, MOCK_VALID_AFTER, feeToken, exchangeRate, priceMarkup]
+//   );
+// };
 
 export async function getUserOpEvent(ep: EntryPoint) {
   const [log] = await ep.queryFilter(
@@ -254,13 +254,23 @@ describe("Biconomy Token Paymaster (with Bundler)", function () {
         DEFAULT_FEE_MARKUP
       );
       const sig = await offchainSigner.signMessage(arrayify(hash));
+      const numVU = ethers.BigNumber.from(MOCK_VALID_UNTIL);
+      const numVA = ethers.BigNumber.from(MOCK_VALID_AFTER);
+      const numER = ethers.BigNumber.from(MOCK_FX);
       const userOp = await fillAndSign(
         {
           ...userOp1,
           paymasterAndData: ethers.utils.hexConcat([
             paymasterAddress,
             ethers.utils.hexlify(1).slice(0, 4),
-            encodePaymasterData(token.address, MOCK_FX, DEFAULT_FEE_MARKUP),
+            ethers.utils.hexZeroPad(ethers.utils.hexlify(numVU.toNumber()), 6), // 6 byte
+            ethers.utils.hexZeroPad(ethers.utils.hexlify(numVA.toNumber()), 6), // 6 byte
+            ethers.utils.hexZeroPad(token.address, 20), // 20 byte
+            ethers.utils.hexZeroPad(ethers.utils.hexlify(numER.toNumber()), 16), // 16 byte
+            ethers.utils.hexZeroPad(
+              ethers.utils.hexlify(DEFAULT_FEE_MARKUP),
+              4
+            ), // 4 byte
             sig,
           ]),
           preVerificationGas: 55000,

--- a/test/bundler-integration/token-paymaster/btpm-undeployed-wallet.ts
+++ b/test/bundler-integration/token-paymaster/btpm-undeployed-wallet.ts
@@ -48,16 +48,16 @@ export async function deployEntryPoint(
   return new EntryPoint__factory(provider.getSigner()).deploy();
 }
 
-export const encodePaymasterData = (
-  feeToken = ethers.constants.AddressZero,
-  exchangeRate: BigNumberish = ethers.constants.Zero,
-  priceMarkup: BigNumberish = ethers.constants.Zero
-) => {
-  return ethers.utils.defaultAbiCoder.encode(
-    ["uint48", "uint48", "address", "uint256", "uint32"],
-    [MOCK_VALID_UNTIL, MOCK_VALID_AFTER, feeToken, exchangeRate, priceMarkup]
-  );
-};
+// export const encodePaymasterData = (
+//   feeToken = ethers.constants.AddressZero,
+//   exchangeRate: BigNumberish = ethers.constants.Zero,
+//   priceMarkup: BigNumberish = ethers.constants.Zero
+// ) => {
+//   return ethers.utils.defaultAbiCoder.encode(
+//     ["uint48", "uint48", "address", "uint256", "uint32"],
+//     [MOCK_VALID_UNTIL, MOCK_VALID_AFTER, feeToken, exchangeRate, priceMarkup]
+//   );
+// };
 
 export async function getUserOpEvent(ep: EntryPoint) {
   const [log] = await ep.queryFilter(
@@ -273,13 +273,23 @@ describe("Biconomy Token Paymaster (with Bundler)", function () {
         DEFAULT_FEE_MARKUP
       );
       const sig = await offchainSigner.signMessage(arrayify(hash));
+      const numVU = ethers.BigNumber.from(MOCK_VALID_UNTIL);
+      const numVA = ethers.BigNumber.from(MOCK_VALID_AFTER);
+      const numER = ethers.BigNumber.from(MOCK_FX);
       const userOp = await fillAndSign(
         {
           ...userOp1,
           paymasterAndData: ethers.utils.hexConcat([
             paymasterAddress,
             ethers.utils.hexlify(1).slice(0, 4),
-            encodePaymasterData(token.address, MOCK_FX, DEFAULT_FEE_MARKUP),
+            ethers.utils.hexZeroPad(ethers.utils.hexlify(numVU.toNumber()), 6), // 6 byte
+            ethers.utils.hexZeroPad(ethers.utils.hexlify(numVA.toNumber()), 6), // 6 byte
+            ethers.utils.hexZeroPad(token.address, 20), // 20 byte
+            ethers.utils.hexZeroPad(ethers.utils.hexlify(numER.toNumber()), 16), // 16 byte
+            ethers.utils.hexZeroPad(
+              ethers.utils.hexlify(DEFAULT_FEE_MARKUP),
+              4
+            ), // 4 byte
             sig,
           ]),
         },

--- a/test/bundler-integration/token-paymaster/btpm-undeployed-wallet.ts
+++ b/test/bundler-integration/token-paymaster/btpm-undeployed-wallet.ts
@@ -14,6 +14,7 @@ import {
   BiconomyTokenPaymaster__factory,
   MockPriceFeed__factory,
   MockToken,
+  MockOracle__factory,
 } from "../../../typechain-types";
 import {
   EcdsaOwnershipRegistryModule,
@@ -134,6 +135,15 @@ describe("Biconomy Token Paymaster (with Bundler)", function () {
       usdcMaticPriceFeedMock.address
     );
 
+    const nativeOracle = await new MockOracle__factory(deployer).deploy(
+      82843594,
+      "MATIC/USD"
+    );
+    const tokenOracle = await new MockOracle__factory(deployer).deploy(
+      100000000,
+      "USDC/USD"
+    );
+
     sampleTokenPaymaster = await new BiconomyTokenPaymaster__factory(
       deployer
     ).deploy(
@@ -144,9 +154,9 @@ describe("Biconomy Token Paymaster (with Bundler)", function () {
 
     await sampleTokenPaymaster.setTokenOracle(
       token.address,
-      18,
       await token.decimals(),
-      usdcMaticPriceFeedMock.address,
+      tokenOracle.address,
+      nativeOracle.address,
       true
     );
 

--- a/test/bundler-integration/token-paymaster/oracle-aggregator-specs.ts
+++ b/test/bundler-integration/token-paymaster/oracle-aggregator-specs.ts
@@ -15,6 +15,7 @@ import {
   MockStalePriceFeed__factory,
   MockPriceFeed__factory,
   MockToken,
+  MockOracle__factory,
 } from "../../../typechain-types";
 import {
   EcdsaOwnershipRegistryModule,
@@ -123,6 +124,15 @@ describe("Biconomy Token Paymaster (With Bundler)", function () {
       deployer
     ).deploy();
 
+    const nativeOracle = await new MockOracle__factory(deployer).deploy(
+      82843594,
+      "MATIC/USD"
+    );
+    const tokenOracle = await new MockOracle__factory(deployer).deploy(
+      100000000,
+      "USDC/USD"
+    );
+
     sampleTokenPaymaster = await new BiconomyTokenPaymaster__factory(
       deployer
     ).deploy(
@@ -133,12 +143,11 @@ describe("Biconomy Token Paymaster (With Bundler)", function () {
 
     await sampleTokenPaymaster.setTokenOracle(
       token.address,
-      18,
       await token.decimals(),
-      usdcMaticPriceFeedMock.address,
+      tokenOracle.address,
+      nativeOracle.address,
       true
     );
-
     const priceResult =
       await sampleTokenPaymaster.getTokenValueOfOneNativeToken(token.address);
 

--- a/test/bundler-integration/token-paymaster/oracle-aggregator-specs.ts
+++ b/test/bundler-integration/token-paymaster/oracle-aggregator-specs.ts
@@ -312,12 +312,12 @@ describe("Biconomy Token Paymaster (With Bundler)", function () {
       );
 
       const eventLogs = BiconomyTokenPaymaster.interface.decodeEventLog(
-        "TokenPaymasterOperation",
+        "UserOperationSponsored",
         receipt.logs[3].data
       );
 
       // Confirming that it's using backup (external) exchange rate in case oracle aggregator / price feed is stale / anything goes wrong
-      expect(eventLogs.exchangeRate).to.be.equal(rate1);
+      // expect(eventLogs.exchangeRate).to.be.equal(rate1);
 
       await expect(
         entryPoint.handleOps([userOp], await offchainSigner.getAddress())

--- a/test/bundler-integration/token-paymaster/oracle-aggregator-specs.ts
+++ b/test/bundler-integration/token-paymaster/oracle-aggregator-specs.ts
@@ -312,12 +312,12 @@ describe("Biconomy Token Paymaster (With Bundler)", function () {
       );
 
       const eventLogs = BiconomyTokenPaymaster.interface.decodeEventLog(
-        "UserOperationSponsored",
+        "TokenPaymasterOperation",
         receipt.logs[3].data
       );
 
       // Confirming that it's using backup (external) exchange rate in case oracle aggregator / price feed is stale / anything goes wrong
-      // expect(eventLogs.exchangeRate).to.be.equal(rate1);
+      expect(eventLogs.exchangeRate).to.be.equal(rate1);
 
       await expect(
         entryPoint.handleOps([userOp], await offchainSigner.getAddress())

--- a/test/bundler-integration/token-paymaster/oracle-aggregator-specs.ts
+++ b/test/bundler-integration/token-paymaster/oracle-aggregator-specs.ts
@@ -41,16 +41,16 @@ const DEFAULT_FEE_MARKUP = 1100000;
 
 const MOCK_FX: BigNumberish = "977100"; // matic to usdc approx
 
-export const encodePaymasterData = (
-  feeToken = ethers.constants.AddressZero,
-  exchangeRate: BigNumberish = ethers.constants.Zero,
-  priceMarkup: BigNumberish = ethers.constants.Zero
-) => {
-  return ethers.utils.defaultAbiCoder.encode(
-    ["uint48", "uint48", "address", "uint256", "uint32"],
-    [MOCK_VALID_UNTIL, MOCK_VALID_AFTER, feeToken, exchangeRate, priceMarkup]
-  );
-};
+// export const encodePaymasterData = (
+//   feeToken = ethers.constants.AddressZero,
+//   exchangeRate: BigNumberish = ethers.constants.Zero,
+//   priceMarkup: BigNumberish = ethers.constants.Zero
+// ) => {
+//   return ethers.utils.defaultAbiCoder.encode(
+//     ["uint48", "uint48", "address", "uint256", "uint32"],
+//     [MOCK_VALID_UNTIL, MOCK_VALID_AFTER, feeToken, exchangeRate, priceMarkup]
+//   );
+// };
 
 export async function getUserOpEvent(ep: EntryPoint) {
   const [log] = await ep.queryFilter(
@@ -268,13 +268,23 @@ describe("Biconomy Token Paymaster (With Bundler)", function () {
         DEFAULT_FEE_MARKUP
       );
       const sig = await offchainSigner.signMessage(arrayify(hash));
+      const numVU = ethers.BigNumber.from(MOCK_VALID_UNTIL);
+      const numVA = ethers.BigNumber.from(MOCK_VALID_AFTER);
+      const numER = ethers.BigNumber.from(MOCK_FX);
       const userOp = await fillAndSign(
         {
           ...userOp1,
           paymasterAndData: ethers.utils.hexConcat([
             paymasterAddress,
             ethers.utils.hexlify(1).slice(0, 4),
-            encodePaymasterData(token.address, MOCK_FX, DEFAULT_FEE_MARKUP),
+            ethers.utils.hexZeroPad(ethers.utils.hexlify(numVU.toNumber()), 6), // 6 byte
+            ethers.utils.hexZeroPad(ethers.utils.hexlify(numVA.toNumber()), 6), // 6 byte
+            ethers.utils.hexZeroPad(token.address, 20), // 20 byte
+            ethers.utils.hexZeroPad(ethers.utils.hexlify(numER.toNumber()), 16), // 16 byte
+            ethers.utils.hexZeroPad(
+              ethers.utils.hexlify(DEFAULT_FEE_MARKUP),
+              4
+            ), // 4 byte
             sig,
           ]),
         },

--- a/test/foundry/base/SATestBase.sol
+++ b/test/foundry/base/SATestBase.sol
@@ -273,11 +273,17 @@ abstract contract SATestBase is Test {
             nonce: entryPoint.getNonce(address(_sa), _nonceKey),
             initCode: bytes(""),
             callData: _calldata,
-            callGasLimit: gasleft() / 100,
-            verificationGasLimit: gasleft() / 100,
-            preVerificationGas: defaultPreVerificationGas,
-            maxFeePerGas: tx.gasprice,
-            maxPriorityFeePerGas: tx.gasprice - block.basefee,
+            // Review: If left to this some test fail
+            // callGasLimit: gasleft() / 100,
+            // verificationGasLimit: gasleft() / 100,
+            // preVerificationGas: defaultPreVerificationGas,
+            // maxFeePerGas: tx.gasprice,
+            // maxPriorityFeePerGas: tx.gasprice - block.basefee,
+            callGasLimit: 100000,
+            verificationGasLimit: 200000,
+            preVerificationGas: 50000,
+            maxFeePerGas: 100000000000,
+            maxPriorityFeePerGas: 40000000000,
             paymasterAndData: _pnd,
             signature: bytes("")
         });

--- a/test/foundry/token-paymaster/TokenPaymaster.t.sol
+++ b/test/foundry/token-paymaster/TokenPaymaster.t.sol
@@ -195,19 +195,17 @@ contract TokenPaymasterTest is SATestBase {
                 .ORACLE_BASED;
         uint48 validUntil = 3735928559;
         uint48 validAfter = 4660;
-        uint256 exchangeRate = 977100;
+        uint128 exchangeRate = 977100;
         uint32 priceMarkup = 1100000;
 
         op.paymasterAndData = abi.encodePacked(
             address(_btpm),
             priceSource,
-            abi.encode(
-                validUntil,
-                validAfter,
-                address(usdc),
-                exchangeRate,
-                priceMarkup
-            ),
+            validUntil,
+            validAfter,
+            address(usdc),
+            exchangeRate,
+            priceMarkup,
             pmSig
         );
 
@@ -302,19 +300,17 @@ contract TokenPaymasterTest is SATestBase {
                 .ORACLE_BASED;
         uint48 validUntil = 3735928559;
         uint48 validAfter = 4660;
-        uint256 exchangeRate = 977100;
+        uint128 exchangeRate = 977100;
         uint32 priceMarkup = 1100000;
 
         op.paymasterAndData = abi.encodePacked(
             address(_btpm),
             priceSource,
-            abi.encode(
-                validUntil,
-                validAfter,
-                address(usdc),
-                exchangeRate,
-                priceMarkup
-            ),
+            validUntil,
+            validAfter,
+            address(usdc),
+            exchangeRate,
+            priceMarkup,
             pmSig
         );
         op.signature = signUserOp(op, keyUser);
@@ -352,19 +348,17 @@ contract TokenPaymasterTest is SATestBase {
                 .ORACLE_BASED;
         uint48 validUntil = 3735928559;
         uint48 validAfter = 4660;
-        uint256 exchangeRate = 977100;
+        uint128 exchangeRate = 977100;
         uint32 priceMarkup = 1100000;
 
         op.paymasterAndData = abi.encodePacked(
             address(_btpm),
             priceSource,
-            abi.encode(
-                validUntil,
-                validAfter,
-                address(usdc),
-                exchangeRate,
-                priceMarkup
-            ),
+            validUntil,
+            validAfter,
+            address(usdc),
+            exchangeRate,
+            priceMarkup,
             pmSig
         );
         op.signature = signUserOp(op, keyUser);
@@ -397,7 +391,7 @@ contract TokenPaymasterTest is SATestBase {
                 .ORACLE_BASED;
         uint48 validUntil = 3735928559;
         uint48 validAfter = 4660;
-        uint256 exchangeRate = 977100;
+        uint128 exchangeRate = 977100;
         uint32 priceMarkup = 2200000;
 
         bytes32 hash = _btpm.getHash(
@@ -418,13 +412,11 @@ contract TokenPaymasterTest is SATestBase {
         op.paymasterAndData = abi.encodePacked(
             address(_btpm),
             priceSource,
-            abi.encode(
-                validUntil,
-                validAfter,
-                address(usdc),
-                exchangeRate,
-                priceMarkup
-            ),
+            validUntil,
+            validAfter,
+            address(usdc),
+            exchangeRate,
+            priceMarkup,
             pmSig
         );
         op.signature = signUserOp(op, keyUser);
@@ -451,7 +443,7 @@ contract TokenPaymasterTest is SATestBase {
                 .ORACLE_BASED;
         uint48 validUntil = 3735928559;
         uint48 validAfter = 4660;
-        uint256 exchangeRate = 977100;
+        uint128 exchangeRate = 977100;
         uint32 priceMarkup = 1100000;
 
         bytes32 hash = _btpm.getHash(

--- a/test/token-paymaster/biconomy-token-paymaster-specs.ts
+++ b/test/token-paymaster/biconomy-token-paymaster-specs.ts
@@ -50,16 +50,16 @@ export async function deployEntryPoint(
   return new EntryPoint__factory(provider.getSigner()).deploy();
 }
 
-export const encodePaymasterData = (
-  feeToken = ethers.constants.AddressZero,
-  exchangeRate: BigNumberish = ethers.constants.Zero,
-  priceMarkup: BigNumberish = ethers.constants.Zero
-) => {
-  return ethers.utils.defaultAbiCoder.encode(
-    ["uint48", "uint48", "address", "uint256", "uint32"],
-    [MOCK_VALID_UNTIL, MOCK_VALID_AFTER, feeToken, exchangeRate, priceMarkup]
-  );
-};
+// export const encodePaymasterData = (
+//   feeToken = ethers.constants.AddressZero,
+//   exchangeRate: BigNumberish = ethers.constants.Zero,
+//   priceMarkup: BigNumberish = ethers.constants.Zero
+// ) => {
+//   return ethers.utils.defaultAbiCoder.encode(
+//     ["uint48", "uint48", "address", "uint256", "uint32"],
+//     [MOCK_VALID_UNTIL, MOCK_VALID_AFTER, feeToken, exchangeRate, priceMarkup]
+//   );
+// };
 
 export async function getUserOpEvent(ep: EntryPoint) {
   const [log] = await ep.queryFilter(
@@ -207,10 +207,18 @@ describe("Biconomy Token Paymaster", function () {
 
   describe("Token Payamster read methods and state checks", () => {
     it("Should parse data properly", async () => {
+      const numVU = ethers.BigNumber.from(MOCK_VALID_UNTIL);
+      const numVA = ethers.BigNumber.from(MOCK_VALID_AFTER);
+      const numER = ethers.BigNumber.from(MOCK_FX);
+
       const paymasterAndData = ethers.utils.hexConcat([
         paymasterAddress,
         ethers.utils.hexlify(1).slice(0, 4),
-        encodePaymasterData(token.address, MOCK_FX, DEFAULT_FEE_MARKUP),
+        ethers.utils.hexZeroPad(ethers.utils.hexlify(numVU.toNumber()), 6), // 6 byte
+        ethers.utils.hexZeroPad(ethers.utils.hexlify(numVA.toNumber()), 6), // 6 byte
+        ethers.utils.hexZeroPad(token.address, 20), // 20 byte
+        ethers.utils.hexZeroPad(ethers.utils.hexlify(numER.toNumber()), 16), // 16 byte
+        ethers.utils.hexZeroPad(ethers.utils.hexlify(DEFAULT_FEE_MARKUP), 4), // 4 byte
         "0x" + "00".repeat(65),
       ]);
 
@@ -219,11 +227,18 @@ describe("Biconomy Token Paymaster", function () {
       );
 
       expect(res.priceSource).to.equal(1);
+
+      console.log(res.validUntil);
+
       expect(res.priceMarkup).to.equal(DEFAULT_FEE_MARKUP);
-      expect(res.validUntil).to.equal(ethers.BigNumber.from(MOCK_VALID_UNTIL));
-      expect(res.validAfter).to.equal(ethers.BigNumber.from(MOCK_VALID_AFTER));
+      expect(res.validUntil).to.equal(
+        ethers.BigNumber.from(MOCK_VALID_UNTIL).toNumber()
+      );
+      expect(res.validAfter).to.equal(
+        ethers.BigNumber.from(MOCK_VALID_AFTER).toNumber()
+      );
       expect(res.feeToken).to.equal(token.address);
-      expect(res.exchangeRate).to.equal(MOCK_FX);
+      expect(res.exchangeRate).to.equal(BigNumber.from(MOCK_FX).toNumber());
       expect(res.signature).to.equal("0x" + "00".repeat(65));
     });
 
@@ -300,13 +315,25 @@ describe("Biconomy Token Paymaster", function () {
         DEFAULT_FEE_MARKUP
       );
       const sig = await offchainSigner.signMessage(arrayify(hash));
+
+      const numVU = ethers.BigNumber.from(MOCK_VALID_UNTIL);
+      const numVA = ethers.BigNumber.from(MOCK_VALID_AFTER);
+      const numER = ethers.BigNumber.from(MOCK_FX);
+
       const userOp = await fillAndSign(
         {
           ...userOp1,
           paymasterAndData: ethers.utils.hexConcat([
             paymasterAddress,
             ethers.utils.hexlify(1).slice(0, 4),
-            encodePaymasterData(token.address, MOCK_FX, DEFAULT_FEE_MARKUP),
+            ethers.utils.hexZeroPad(ethers.utils.hexlify(numVU.toNumber()), 6), // 6 byte
+            ethers.utils.hexZeroPad(ethers.utils.hexlify(numVA.toNumber()), 6), // 6 byte
+            ethers.utils.hexZeroPad(token.address, 20), // 20 byte
+            ethers.utils.hexZeroPad(ethers.utils.hexlify(numER.toNumber()), 16), // 16 byte
+            ethers.utils.hexZeroPad(
+              ethers.utils.hexlify(DEFAULT_FEE_MARKUP),
+              4
+            ), // 4 byte
             sig,
           ]),
         },
@@ -314,6 +341,8 @@ describe("Biconomy Token Paymaster", function () {
         entryPoint,
         "nonce"
       );
+      console.log("pnd ", userOp.paymasterAndData);
+
       console.log("pnd ", userOp.paymasterAndData);
 
       const signatureWithModuleAddress = ethers.utils.defaultAbiCoder.encode(
@@ -335,14 +364,13 @@ describe("Biconomy Token Paymaster", function () {
       );
       const receipt = await tx.wait();
 
+      console.log("paymaster and data length", userOp.paymasterAndData.length);
       const gasUsed = receipt.gasUsed.toNumber();
       console.log("gas used token paymaster", gasUsed);
       console.log(
         "fees paid in native ",
         receipt.effectiveGasPrice.mul(receipt.gasUsed).toString()
       );
-
-      console.log("paymaster data length ", userOp.paymasterAndData.length);
 
       const postBalance = await token.balanceOf(paymasterAddress);
 
@@ -365,6 +393,10 @@ describe("Biconomy Token Paymaster", function () {
         deployer
       );
 
+      const numVU = ethers.BigNumber.from(MOCK_VALID_UNTIL);
+      const numVA = ethers.BigNumber.from(MOCK_VALID_AFTER);
+      const numER = ethers.BigNumber.from(MOCK_FX);
+
       const userOp = await fillAndSign(
         {
           sender: walletAddress,
@@ -380,7 +412,15 @@ describe("Biconomy Token Paymaster", function () {
           paymasterAndData: ethers.utils.hexConcat([
             paymasterAddress,
             ethers.utils.hexlify(1).slice(0, 4),
-            encodePaymasterData(token.address, MOCK_FX),
+            ethers.utils.hexZeroPad(ethers.utils.hexlify(numVU.toNumber()), 6), // 6 byte
+            ethers.utils.hexZeroPad(ethers.utils.hexlify(numVA.toNumber()), 6), // 6 byte
+            ethers.utils.hexZeroPad(token.address, 20), // 20 byte
+            ethers.utils.hexZeroPad(ethers.utils.hexlify(numER.toNumber()), 16), // 16 byte
+            ethers.utils.hexZeroPad(
+              ethers.utils.hexlify(DEFAULT_FEE_MARKUP),
+              4
+            ), // 4 byte
+
             "0x1234",
           ]),
         },
@@ -487,6 +527,10 @@ describe("Biconomy Token Paymaster", function () {
         deployer
       );
 
+      const numVU = ethers.BigNumber.from(MOCK_VALID_UNTIL);
+      const numVA = ethers.BigNumber.from(MOCK_VALID_AFTER);
+      const numER = ethers.BigNumber.from(MOCK_FX);
+
       const userOp = await fillAndSign(
         {
           sender: walletAddress,
@@ -502,7 +546,14 @@ describe("Biconomy Token Paymaster", function () {
           paymasterAndData: ethers.utils.hexConcat([
             paymasterAddress,
             ethers.utils.hexlify(1).slice(0, 4),
-            encodePaymasterData(token.address, MOCK_FX),
+            ethers.utils.hexZeroPad(ethers.utils.hexlify(numVU.toNumber()), 6), // 6 byte
+            ethers.utils.hexZeroPad(ethers.utils.hexlify(numVA.toNumber()), 6), // 6 byte
+            ethers.utils.hexZeroPad(token.address, 20), // 20 byte
+            ethers.utils.hexZeroPad(ethers.utils.hexlify(numER.toNumber()), 16), // 16 byte
+            ethers.utils.hexZeroPad(
+              ethers.utils.hexlify(DEFAULT_FEE_MARKUP),
+              4
+            ), // 4 byte
             "0x" + "00".repeat(65),
           ]),
         },
@@ -533,6 +584,10 @@ describe("Biconomy Token Paymaster", function () {
         ethers.utils.arrayify("0xdead")
       );
 
+      const numVU = ethers.BigNumber.from(MOCK_VALID_UNTIL);
+      const numVA = ethers.BigNumber.from(MOCK_VALID_AFTER);
+      const numER = ethers.BigNumber.from(MOCK_FX);
+
       const wrongUserOp = await fillAndSign(
         {
           sender: walletAddress,
@@ -548,7 +603,14 @@ describe("Biconomy Token Paymaster", function () {
           paymasterAndData: ethers.utils.hexConcat([
             paymasterAddress,
             ethers.utils.hexlify(1).slice(0, 4),
-            encodePaymasterData(token.address, MOCK_FX),
+            ethers.utils.hexZeroPad(ethers.utils.hexlify(numVU.toNumber()), 6), // 6 byte
+            ethers.utils.hexZeroPad(ethers.utils.hexlify(numVA.toNumber()), 6), // 6 byte
+            ethers.utils.hexZeroPad(token.address, 20), // 20 byte
+            ethers.utils.hexZeroPad(ethers.utils.hexlify(numER.toNumber()), 16), // 16 byte
+            ethers.utils.hexZeroPad(
+              ethers.utils.hexlify(DEFAULT_FEE_MARKUP),
+              4
+            ), // 4 byte
             sig,
           ]),
         },
@@ -619,6 +681,9 @@ describe("Biconomy Token Paymaster", function () {
         MOCK_FX,
         DEFAULT_FEE_MARKUP
       );
+      const numVU = ethers.BigNumber.from(MOCK_VALID_UNTIL);
+      const numVA = ethers.BigNumber.from(MOCK_VALID_AFTER);
+      const numER = ethers.BigNumber.from(MOCK_FX);
       const sig = await offchainSigner.signMessage(arrayify(hash));
       const userOp = await fillAndSign(
         {
@@ -626,7 +691,14 @@ describe("Biconomy Token Paymaster", function () {
           paymasterAndData: ethers.utils.hexConcat([
             paymasterAddress,
             ethers.utils.hexlify(1).slice(0, 4),
-            encodePaymasterData(token.address, MOCK_FX, DEFAULT_FEE_MARKUP),
+            ethers.utils.hexZeroPad(ethers.utils.hexlify(numVU.toNumber()), 6), // 6 byte
+            ethers.utils.hexZeroPad(ethers.utils.hexlify(numVA.toNumber()), 6), // 6 byte
+            ethers.utils.hexZeroPad(token.address, 20), // 20 byte
+            ethers.utils.hexZeroPad(ethers.utils.hexlify(numER.toNumber()), 16), // 16 byte
+            ethers.utils.hexZeroPad(
+              ethers.utils.hexlify(DEFAULT_FEE_MARKUP),
+              4
+            ), // 4 byte
             sig,
           ]),
         },
@@ -693,6 +765,9 @@ describe("Biconomy Token Paymaster", function () {
         MOCK_FX,
         2200000 // > 2x!
       );
+      const numVU = ethers.BigNumber.from(MOCK_VALID_UNTIL);
+      const numVA = ethers.BigNumber.from(MOCK_VALID_AFTER);
+      const numER = ethers.BigNumber.from(MOCK_FX);
       const sig = await offchainSigner.signMessage(arrayify(hash));
       const userOp = await fillAndSign(
         {
@@ -700,7 +775,11 @@ describe("Biconomy Token Paymaster", function () {
           paymasterAndData: ethers.utils.hexConcat([
             paymasterAddress,
             ethers.utils.hexlify(1).slice(0, 4),
-            encodePaymasterData(token.address, MOCK_FX, 2200000),
+            ethers.utils.hexZeroPad(ethers.utils.hexlify(numVU.toNumber()), 6), // 6 byte
+            ethers.utils.hexZeroPad(ethers.utils.hexlify(numVA.toNumber()), 6), // 6 byte
+            ethers.utils.hexZeroPad(token.address, 20), // 20 byte
+            ethers.utils.hexZeroPad(ethers.utils.hexlify(numER.toNumber()), 16), // 16 byte
+            ethers.utils.hexZeroPad(ethers.utils.hexlify(2200000), 4), // 4 byte
             sig,
           ]),
         },

--- a/test/token-paymaster/biconomy-token-paymaster-specs.ts
+++ b/test/token-paymaster/biconomy-token-paymaster-specs.ts
@@ -314,6 +314,7 @@ describe("Biconomy Token Paymaster", function () {
         entryPoint,
         "nonce"
       );
+      console.log("pnd ", userOp.paymasterAndData);
 
       const signatureWithModuleAddress = ethers.utils.defaultAbiCoder.encode(
         ["bytes", "address"],
@@ -341,8 +342,7 @@ describe("Biconomy Token Paymaster", function () {
         receipt.effectiveGasPrice.mul(receipt.gasUsed).toString()
       );
 
-      console.log("gas used ");
-      console.log(receipt.gasUsed.toNumber());
+      console.log("paymaster data length ", userOp.paymasterAndData.length);
 
       const postBalance = await token.balanceOf(paymasterAddress);
 

--- a/test/token-paymaster/btpm-coverage-specs.ts
+++ b/test/token-paymaster/btpm-coverage-specs.ts
@@ -15,6 +15,7 @@ import {
   MockPriceFeed,
   MockPriceFeed__factory,
   MockToken,
+  MockOracle__factory,
 } from "../../typechain-types";
 
 import { fillAndSign } from "../../lib/account-abstraction/test/UserOp";
@@ -142,6 +143,15 @@ describe("Biconomy Token Paymaster", function () {
       deployer
     ).deploy();
 
+    const nativeOracle = await new MockOracle__factory(deployer).deploy(
+      82843594,
+      "MATIC/USD"
+    );
+    const tokenOracle = await new MockOracle__factory(deployer).deploy(
+      100000000,
+      "USDC/USD"
+    );
+
     sampleTokenPaymaster = await new BiconomyTokenPaymaster__factory(
       deployer
     ).deploy(
@@ -152,9 +162,9 @@ describe("Biconomy Token Paymaster", function () {
 
     await sampleTokenPaymaster.setTokenOracle(
       token.address,
-      18,
       await token.decimals(),
-      usdcMaticPriceFeedMock.address,
+      tokenOracle.address,
+      nativeOracle.address,
       true
     );
 

--- a/test/token-paymaster/btpm-coverage-specs.ts
+++ b/test/token-paymaster/btpm-coverage-specs.ts
@@ -59,22 +59,16 @@ function delay(ms: number) {
   });
 }
 
-export const encodePaymasterData = (
-  feeToken = ethers.constants.AddressZero,
-  exchangeRate: BigNumberish = ethers.constants.Zero,
-  priceMarkup: BigNumberish = ethers.constants.Zero
-) => {
-  return ethers.utils.defaultAbiCoder.encode(
-    ["uint48", "uint48", "address", "address", "uint256", "uint32"],
-    [
-      MOCK_VALID_UNTIL,
-      MOCK_VALID_AFTER,
-      feeToken,
-      exchangeRate,
-      priceMarkup,
-    ]
-  );
-};
+// export const encodePaymasterData = (
+//   feeToken = ethers.constants.AddressZero,
+//   exchangeRate: BigNumberish = ethers.constants.Zero,
+//   priceMarkup: BigNumberish = ethers.constants.Zero
+// ) => {
+//   return ethers.utils.defaultAbiCoder.encode(
+//     ["uint48", "uint48", "address", "address", "uint256", "uint32"],
+//     [MOCK_VALID_UNTIL, MOCK_VALID_AFTER, feeToken, exchangeRate, priceMarkup]
+//   );
+// };
 
 export async function getUserOpEvent(ep: EntryPoint) {
   const [log] = await ep.queryFilter(

--- a/test/token-paymaster/btpm-undeployed-wallet.ts
+++ b/test/token-paymaster/btpm-undeployed-wallet.ts
@@ -15,6 +15,7 @@ import {
   MockPriceFeed,
   MockPriceFeed__factory,
   MockToken,
+  MockOracle__factory,
 } from "../../typechain-types";
 
 // Review: Could import from scw-contracts submodules to be consistent
@@ -141,6 +142,15 @@ describe("Biconomy Token Paymaster", function () {
     const priceFeedTxUsdc: any =
       await priceFeedUsdc.populateTransaction.getThePrice();
 
+    const nativeOracle = await new MockOracle__factory(deployer).deploy(
+      82843594,
+      "MATIC/USD"
+    );
+    const tokenOracle = await new MockOracle__factory(deployer).deploy(
+      100000000,
+      "USDC/USD"
+    );
+
     sampleTokenPaymaster = await new BiconomyTokenPaymaster__factory(
       deployer
     ).deploy(
@@ -151,9 +161,9 @@ describe("Biconomy Token Paymaster", function () {
 
     await sampleTokenPaymaster.setTokenOracle(
       token.address,
-      18,
       await token.decimals(),
-      usdcMaticPriceFeedMock.address,
+      tokenOracle.address,
+      nativeOracle.address,
       true
     );
 

--- a/test/token-paymaster/btpm-undeployed-wallet.ts
+++ b/test/token-paymaster/btpm-undeployed-wallet.ts
@@ -56,16 +56,16 @@ export async function deployEntryPoint(
   return new EntryPoint__factory(provider.getSigner()).deploy();
 }
 
-export const encodePaymasterData = (
-  feeToken = ethers.constants.AddressZero,
-  exchangeRate: BigNumberish = ethers.constants.Zero,
-  priceMarkup: BigNumberish = ethers.constants.Zero
-) => {
-  return ethers.utils.defaultAbiCoder.encode(
-    ["uint48", "uint48", "address", "uint256", "uint32"],
-    [MOCK_VALID_UNTIL, MOCK_VALID_AFTER, feeToken, exchangeRate, priceMarkup]
-  );
-};
+// export const encodePaymasterData = (
+//   feeToken = ethers.constants.AddressZero,
+//   exchangeRate: BigNumberish = ethers.constants.Zero,
+//   priceMarkup: BigNumberish = ethers.constants.Zero
+// ) => {
+//   return ethers.utils.defaultAbiCoder.encode(
+//     ["uint48", "uint48", "address", "uint256", "uint32"],
+//     [MOCK_VALID_UNTIL, MOCK_VALID_AFTER, feeToken, exchangeRate, priceMarkup]
+//   );
+// };
 
 export async function getUserOpEvent(ep: EntryPoint) {
   const [log] = await ep.queryFilter(
@@ -207,10 +207,17 @@ describe("Biconomy Token Paymaster", function () {
 
   describe("Token Payamster read methods and state checks", () => {
     it("Should parse data properly", async () => {
+      const numVU = ethers.BigNumber.from(MOCK_VALID_UNTIL);
+      const numVA = ethers.BigNumber.from(MOCK_VALID_AFTER);
+      const numER = ethers.BigNumber.from(MOCK_FX);
       const paymasterAndData = ethers.utils.hexConcat([
         paymasterAddress,
         ethers.utils.hexlify(1).slice(0, 4),
-        encodePaymasterData(token.address, MOCK_FX, DEFAULT_FEE_MARKUP),
+        ethers.utils.hexZeroPad(ethers.utils.hexlify(numVU.toNumber()), 6), // 6 byte
+        ethers.utils.hexZeroPad(ethers.utils.hexlify(numVA.toNumber()), 6), // 6 byte
+        ethers.utils.hexZeroPad(token.address, 20), // 20 byte
+        ethers.utils.hexZeroPad(ethers.utils.hexlify(numER.toNumber()), 16), // 16 byte
+        ethers.utils.hexZeroPad(ethers.utils.hexlify(DEFAULT_FEE_MARKUP), 4), // 4 byte
         "0x" + "00".repeat(65),
       ]);
 
@@ -300,13 +307,23 @@ describe("Biconomy Token Paymaster", function () {
         DEFAULT_FEE_MARKUP
       );
       const sig = await offchainSigner.signMessage(arrayify(hash));
+      const numVU = ethers.BigNumber.from(MOCK_VALID_UNTIL);
+      const numVA = ethers.BigNumber.from(MOCK_VALID_AFTER);
+      const numER = ethers.BigNumber.from(MOCK_FX);
       const userOp = await fillAndSign(
         {
           ...userOp1,
           paymasterAndData: ethers.utils.hexConcat([
             paymasterAddress,
             ethers.utils.hexlify(1).slice(0, 4),
-            encodePaymasterData(token.address, MOCK_FX, DEFAULT_FEE_MARKUP),
+            ethers.utils.hexZeroPad(ethers.utils.hexlify(numVU.toNumber()), 6), // 6 byte
+            ethers.utils.hexZeroPad(ethers.utils.hexlify(numVA.toNumber()), 6), // 6 byte
+            ethers.utils.hexZeroPad(token.address, 20), // 20 byte
+            ethers.utils.hexZeroPad(ethers.utils.hexlify(numER.toNumber()), 16), // 16 byte
+            ethers.utils.hexZeroPad(
+              ethers.utils.hexlify(DEFAULT_FEE_MARKUP),
+              4
+            ), // 4 byte
             sig,
           ]),
         },

--- a/test/token-paymaster/oracle-aggregator-specs.ts
+++ b/test/token-paymaster/oracle-aggregator-specs.ts
@@ -311,12 +311,12 @@ describe("Biconomy Token Paymaster", function () {
       );
 
       const eventLogs = BiconomyTokenPaymaster.interface.decodeEventLog(
-        "TokenPaymasterOperation",
+        "UserOperationSponsored",
         receipt.logs[3].data
       );
 
       // Confirming that it's using backup (external) exchange rate in case oracle aggregator / price feed is stale / anything goes wrong
-      expect(eventLogs.exchangeRate).to.be.equal(rate1);
+      // expect(eventLogs.exchangeRate).to.be.equal(rate1);
 
       await expect(
         entryPoint.handleOps([userOp], await offchainSigner.getAddress())

--- a/test/token-paymaster/oracle-aggregator-specs.ts
+++ b/test/token-paymaster/oracle-aggregator-specs.ts
@@ -17,6 +17,7 @@ import {
   MockStalePriceFeed,
   MockPriceFeed__factory,
   MockToken,
+  MockOracle__factory,
 } from "../../typechain-types";
 
 // Review: Could import from scw-contracts submodules to be consistent
@@ -140,6 +141,15 @@ describe("Biconomy Token Paymaster", function () {
       stalePriceFeedMock.address
     );
 
+    const nativeOracle = await new MockOracle__factory(deployer).deploy(
+      82843594,
+      "MATIC/USD"
+    );
+    const tokenOracle = await new MockOracle__factory(deployer).deploy(
+      100000000,
+      "USDC/USD"
+    );
+
     sampleTokenPaymaster = await new BiconomyTokenPaymaster__factory(
       deployer
     ).deploy(
@@ -150,9 +160,9 @@ describe("Biconomy Token Paymaster", function () {
 
     await sampleTokenPaymaster.setTokenOracle(
       token.address,
-      18,
       await token.decimals(),
-      usdcMaticPriceFeedMock.address,
+      tokenOracle.address,
+      nativeOracle.address,
       true
     );
 

--- a/test/token-paymaster/oracle-aggregator-specs.ts
+++ b/test/token-paymaster/oracle-aggregator-specs.ts
@@ -311,12 +311,12 @@ describe("Biconomy Token Paymaster", function () {
       );
 
       const eventLogs = BiconomyTokenPaymaster.interface.decodeEventLog(
-        "UserOperationSponsored",
+        "TokenPaymasterOperation",
         receipt.logs[3].data
       );
 
       // Confirming that it's using backup (external) exchange rate in case oracle aggregator / price feed is stale / anything goes wrong
-      // expect(eventLogs.exchangeRate).to.be.equal(rate1);
+      expect(eventLogs.exchangeRate).to.be.equal(rate1);
 
       await expect(
         entryPoint.handleOps([userOp], await offchainSigner.getAddress())

--- a/test/token-paymaster/oracle-aggregator-specs.ts
+++ b/test/token-paymaster/oracle-aggregator-specs.ts
@@ -48,16 +48,16 @@ export async function deployEntryPoint(
   return new EntryPoint__factory(provider.getSigner()).deploy();
 }
 
-export const encodePaymasterData = (
-  feeToken = ethers.constants.AddressZero,
-  exchangeRate: BigNumberish = ethers.constants.Zero,
-  priceMarkup: BigNumberish = ethers.constants.Zero
-) => {
-  return ethers.utils.defaultAbiCoder.encode(
-    ["uint48", "uint48", "address", "uint256", "uint32"],
-    [MOCK_VALID_UNTIL, MOCK_VALID_AFTER, feeToken, exchangeRate, priceMarkup]
-  );
-};
+// export const encodePaymasterData = (
+//   feeToken = ethers.constants.AddressZero,
+//   exchangeRate: BigNumberish = ethers.constants.Zero,
+//   priceMarkup: BigNumberish = ethers.constants.Zero
+// ) => {
+//   return ethers.utils.defaultAbiCoder.encode(
+//     ["uint48", "uint48", "address", "uint256", "uint32"],
+//     [MOCK_VALID_UNTIL, MOCK_VALID_AFTER, feeToken, exchangeRate, priceMarkup]
+//   );
+// };
 
 export async function getUserOpEvent(ep: EntryPoint) {
   const [log] = await ep.queryFilter(
@@ -275,13 +275,23 @@ describe("Biconomy Token Paymaster", function () {
         DEFAULT_FEE_MARKUP
       );
       const sig = await offchainSigner.signMessage(arrayify(hash));
+      const numVU = ethers.BigNumber.from(MOCK_VALID_UNTIL);
+      const numVA = ethers.BigNumber.from(MOCK_VALID_AFTER);
+      const numER = ethers.BigNumber.from(MOCK_FX);
       const userOp = await fillAndSign(
         {
           ...userOp1,
           paymasterAndData: ethers.utils.hexConcat([
             paymasterAddress,
             ethers.utils.hexlify(1).slice(0, 4),
-            encodePaymasterData(token.address, MOCK_FX, DEFAULT_FEE_MARKUP),
+            ethers.utils.hexZeroPad(ethers.utils.hexlify(numVU.toNumber()), 6), // 6 byte
+            ethers.utils.hexZeroPad(ethers.utils.hexlify(numVA.toNumber()), 6), // 6 byte
+            ethers.utils.hexZeroPad(token.address, 20), // 20 byte
+            ethers.utils.hexZeroPad(ethers.utils.hexlify(numER.toNumber()), 16), // 16 byte
+            ethers.utils.hexZeroPad(
+              ethers.utils.hexlify(DEFAULT_FEE_MARKUP),
+              4
+            ), // 4 byte
             sig,
           ]),
         },


### PR DESCRIPTION
# Summary

Changing the way setTokenOracle is called and tokenInfo is maintained.
Instead of calling getThePrice or latestRoundData on callAddress based on derivedFeed boolean, now in case of derived feed we call tokenOracle and nativeOracle and calculate within this Oracle Aggregator contract itself. This saves a contract call to derived feed + need to deploy any derived price feeds. 

## Change Type

- [ ] Bug Fix
- [ ] Refactor
- [ ] New Feature
- [x] Breaking Change
- [ ] Documentation Update
- [x] Performance Improvement
- [ ] Other

# Checklist

- [ ] My code follows this project's style guidelines
- [ ] I've reviewed my own code
- [ ] I've added comments for any hard-to-understand areas
- [ ] I've updated the documentation if necessary
- [ ] My changes generate no new warnings
- [ ] I've added tests that prove my fix is effective or my feature works
- [ ] All unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published

# Additional Information
<!-- Any additional information or context about the PR. -->

# Branch Naming
<!-- Make sure your branch name follows the pattern: `features/`, `fixes/`, or `releases/`. -->
<!-- **Note**: The person creating the PR is responsible for merging and deleting the branch. Ensure the code has been tested, commented, linted, and documents updated if needed. -->